### PR TITLE
Update README to emphasize embedded scripting focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 [![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-blue?logo=go&logoColor=white)](https://pkg.go.dev/github.com/deepnoodle-ai/risor/v2)
 [![Apache-2.0 license](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Risor is a fast, embeddable expression language for Go applications.
+Risor is a fast, embeddable scripting language for Go applications.
 
 Add dynamic expressions, filters, and user-defined logic to your Go programs
-without embedding a heavy runtime. Expressions compile to bytecode and run on a
-lightweight VM. Pure Go, minimal dependencies.
+without embedding a heavy runtime like V8 or Python. Expressions compile to
+bytecode and run on a lightweight VM. Pure Go, minimal dependencies.
+
+Risor fills the gap between hardcoded logic and a full language runtime. It's
+for Go developers who need to evaluate user-provided expressions, rules, or
+small scripts safely at runtime.
 
 ```ts
 // Expression evaluation: access control, validation rules
@@ -50,13 +54,30 @@ allowed, err := risor.Eval(ctx,
 
 Go primitives, slices, and maps convert automatically.
 
+## Use Cases
+
+Risor is designed for scenarios where a Go application needs to evaluate
+user-provided or externally-defined logic at runtime:
+
+- **Business rules & workflow engines** — Conditions like `order.total > 100 && customer.tier == "gold"` that decide branching, eligibility, or routing without redeployment
+- **Expression evaluation** — Dynamic filters, computed fields, validation rules, access control predicates
+- **String templating** — Interpolated strings with embedded expressions for notifications, reports, emails
+- **Configuration logic** — When static config (YAML, JSON) isn't enough but a full language is too much
+- **Data transformation** — User-defined transforms, enrichment, and filtering in data pipelines
+- **Plugin & extension systems** — Let users or tenants write small scripts that customize application behavior
+
+The common pattern: a compiled Go host handles performance-critical work and
+exposes an API surface to Risor for flexible, safe, easy-to-change logic.
+
 ## What Risor Isn't
 
-Risor is not trying to compete with Python, Typescript, or other general purpose
-scripting languages. Nor is it intended for writing large programs, hence there
-is no package manager or module import mechanism in the language. That said,
-there are several easy ways to customize and extend the environment and
-built-in functions and types available to Risor expressions during execution.
+Risor is not a general-purpose programming language. It's not trying to replace
+Python or TypeScript for writing applications. There is no package manager,
+no module imports, and no third-party ecosystem — by design.
+
+Extension happens through Go code: you add builtin functions, pass data into the
+script context, and read results back out. This keeps the core small and lets
+each application tailor Risor to its needs.
 
 ## Documentation
 
@@ -66,9 +87,13 @@ built-in functions and types available to Risor expressions during execution.
 
 ## Risor v2
 
-This is Risor v2, a major evolution focused on the embedded scripting use case.
-Implementations of Risor v2 for use in Typescript and Rust programs is currently
-being prototyped, with good initial results.
+This is Risor v2, a major evolution focused entirely on the embedded scripting
+use case. v1 also served DevOps scripting, cloud tooling, and CLI usage. v2
+narrows the focus to doing one thing well: giving Go developers a safe, fast way
+to evaluate user-provided expressions and scripts at runtime.
+
+Implementations for TypeScript and Rust host programs are being prototyped, with
+good initial results.
 
 Risor v1 remains available at [tag v1.8.1](https://github.com/deepnoodle-ai/risor/releases/tag/v1.8.1).
 


### PR DESCRIPTION
## Summary

- Reframe opening description around embedded scripting (not just expressions)
- Add explicit "Use Cases" section covering business rules, workflow engines, data transformation, plugin systems, etc.
- Rewrite "What Risor Isn't" to be more direct about positioning
- Clarify the v1 → v2 shift: v1 served DevOps/cloud/CLI, v2 narrows focus to embedded scripting

## Test plan

- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with clearer descriptions of Risor's purpose as an embedded scripting language for Go developers
  * Added Use Cases section covering business rules, expression evaluation, string templating, configuration logic, data transformation, and plugin/extension systems
  * Refined explanations of Risor's scope and positioning for runtime evaluation of user-provided logic
  * Updated examples to better reflect the scripting and embedding narrative

<!-- end of auto-generated comment: release notes by coderabbit.ai -->