### PR TITLE
Switch Docker image repo to deepnoodle/risor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ docker-build-init:
 .PHONY: docker-build
 docker-build:
 	docker buildx build \
-		-t risor/risor:latest \
-		-t risor/risor:$(GIT_REVISION) \
-		-t risor/risor:$(VERSION) \
+		-t deepnoodle/risor:latest \
+		-t deepnoodle/risor:$(GIT_REVISION) \
+		-t deepnoodle/risor:$(VERSION) \
 		--build-arg "RISOR_VERSION=$(VERSION)" \
 		--build-arg "GIT_REVISION=$(GIT_REVISION)" \
 		--build-arg "BUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')" \

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -39,9 +39,9 @@ make docker-build
 
 This pushes multi-arch images (amd64, arm64) to Docker Hub:
 
-- `risor/risor:latest`
-- `risor/risor:<version>` (derived from the git tag)
-- `risor/risor:<git-revision>`
+- `deepnoodle/risor:latest`
+- `deepnoodle/risor:<version>` (derived from the git tag)
+- `deepnoodle/risor:<git-revision>`
 
 The version is derived automatically from `git describe --tags`.
 


### PR DESCRIPTION
## Summary
- Updates Makefile `docker-build` target to push to `deepnoodle/risor` instead of `risor/risor`
- Updates release guide to reflect the new Docker Hub repository

## Test plan
- [ ] Verify `make -n docker-build` shows the correct image tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image namespace to deepnoodle/risor across build configuration and release documentation for all release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->