### PR TITLE
Fix closure cells trampled by reused extendedLocals slice (#461)

### DIFF
--- a/pkg/vm/frame.go
+++ b/pkg/vm/frame.go
@@ -90,7 +90,13 @@ func (f *frame) CaptureLocals() []object.Object {
 		return f.capturedLocals
 	}
 	if f.extendedLocals != nil {
+		// Hand the heap-allocated slice to the cells, then drop our reference
+		// so the next ActivateCode on this frame slot allocates fresh storage
+		// instead of zeroing this slice and trampling the captured values.
+		// f.locals shares the same backing array, so the running function can
+		// keep reading and writing locals normally.
 		f.capturedLocals = f.extendedLocals
+		f.extendedLocals = nil
 		return f.capturedLocals
 	}
 	newStorage := make([]object.Object, len(f.locals))

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -590,6 +590,33 @@ func TestClosureManyVariables(t *testing.T) {
 	assert.Equal(t, result, object.NewStringList([]string{"hello", "world", "risor", "go"}))
 }
 
+// Regression for issue #461: when a function has more than DefaultFrameLocals
+// locals, the frame uses heap-allocated extendedLocals storage. Earlier code
+// reused that slice on the next activation of the same frame slot, which
+// trampled cells that previous closures had captured into it.
+func TestClosureCaptureAcrossReusedExtendedFrame(t *testing.T) {
+	result, err := run(context.Background(), `
+	let results = []
+	function makeClosures(a, b, c) {
+		return ((x, y, z) => {
+			let c1 = () => "c1:" + y
+			let c2 = () => "c2:" + y
+			let c3 = () => "c3:" + y
+			let c4 = () => "c4:" + y
+			let c5 = () => "c5:" + y
+			let item = [c1, c2, c3, c4, c5]
+			return item
+		})(a, b, c)
+	}
+	["one", "two", "three"].each(name => {
+		results.append(makeClosures("s", name, "t"))
+	})
+	results.map(cs => cs[1]())
+	`)
+	assert.Nil(t, err)
+	assert.Equal(t, result, object.NewStringList([]string{"c2:one", "c2:two", "c2:three"}))
+}
+
 func TestRecursiveExample1(t *testing.T) {
 	result, err := run(context.Background(), `
 	function twoexp(n) {


### PR DESCRIPTION
Fixes #461.

## Problem

Closures inside an IIFE captured the last iteration's value when the IIFE had 3+ parameters, 5+ inner closures, and an intermediate `let` variable before the return. The reporter's reproduction:

```risor
function createClosures(server, name, status) {
    let s = "" + server
    let n = "" + name
    let st = "" + status
    return ((srv, nm, stat) => {
        let c1 = () => { return "c1:" + nm }
        let c2 = () => { return "c2:" + nm }
        let c3 = () => { return "c3:" + nm }
        let c4 = () => { return "c4:" + nm }
        let c5 = () => { return "c5:" + nm }
        let item = [c1, c2, c3, c4, c5]
        return item
    })(s, n, st)
}
```

Calling this from three iterations and invoking `closureArray[1]()` from each produced `c2:three` three times instead of `c2:one`, `c2:two`, `c2:three`.

## Root cause

The bug is in frame storage reuse, not anything closure-specific.

`frame` inlines up to `DefaultFrameLocals` (8) locals in a fixed `f.storage` array. Anything more uses a heap-allocated `f.extendedLocals` slice that is reused across calls at the same frame depth (`ActivateCode` resizes and zeroes it instead of reallocating).

`CaptureLocals()` hands out a pointer into the frame's locals to each closure cell. For the inline-storage path, it copies into fresh heap memory first — safe. For the `extendedLocals` path, it shared the existing slice without detaching it. On the next call at the same depth, `ActivateCode` zeroed and reused that same slice, overwriting the values that the previous iteration's cells still pointed into.

The thresholds in the bug report match the local count exactly. The buggy IIFE has 3 params + 5 closures + `item` = **9 locals**, which exceeds 8 and forces the `extendedLocals` path. Drop any one (2 params, 4 closures, or no `item`) → **≤8 locals** → inline `f.storage` path → existing copy-on-capture works correctly.

## Fix

In `CaptureLocals()`, when handing `extendedLocals` to cells, clear `f.extendedLocals`. The running function continues to use `f.locals`, which shares the same backing array. The next `ActivateCode` on this frame slot sees `cap(f.extendedLocals) == 0` and allocates fresh storage, leaving the captured values intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed closure capture across repeated function activations so captured values are preserved.

* **Tests**
  * Added a regression test to prevent this closure-capture regression from recurring.

* **Documentation / Rendering**
  * Improved formatting of several documentation and type/syntax rendering sites for clearer output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/risor/pull/462)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->