### PR TITLE
Match wrapped error sentinels in == equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- Error equality (`==`) now matches a wrapped error against its underlying
+  sentinel, so `err == fs.err_not_exist` works when `err` was returned from a
+  module that wraps an inner error. The previous behavior compared only error
+  message strings, so wrapped sentinels never matched.
+
+### Notes
+
+- Error message wrapping (e.g. via `%w` in the `error()` builtin) is an
+  implementation detail and not part of the stable scripting API. The
+  underlying chain semantics may change in a future major release.
+
 ## [2.1.0] - 2026-03-10
 
 ### Added

--- a/cmd/risor/doc.go
+++ b/cmd/risor/doc.go
@@ -486,7 +486,8 @@ func docHandlerText(topic string) error {
 			tui.Text("%s", t.Doc).Style(docStyle),
 		}
 		if len(t.Attrs) > 0 {
-			views = append(views,
+			views = append(
+				views,
 				tui.Text(""),
 				tui.Text("METHODS").Style(headingStyle),
 				tui.ForEach(t.Attrs, func(attr object.AttrSpec, _ int) tui.View {
@@ -563,7 +564,8 @@ func docSyntaxText() error {
 	}
 
 	for _, section := range syntaxSections {
-		views = append(views,
+		views = append(
+			views,
 			tui.Text("%s", strings.ToUpper(section.Name)).Style(headingStyle),
 			tui.ForEach(section.Items, func(item SyntaxItem, _ int) tui.View {
 				return tui.Group(
@@ -602,7 +604,8 @@ func docErrorsText() error {
 		// Build views for examples
 		exampleViews := []tui.View{}
 		for _, ex := range pattern.Examples {
-			exampleViews = append(exampleViews,
+			exampleViews = append(
+				exampleViews,
 				tui.Text("  %s", ex.Error).Style(errorStyle),
 				tui.Text("    Bad:  %s", ex.BadCode).Style(nameStyle),
 				tui.Text("    Fix:  %s", ex.Fix).Style(nameStyle),
@@ -611,7 +614,8 @@ func docErrorsText() error {
 			)
 		}
 
-		views = append(views,
+		views = append(
+			views,
 			tui.Text("%s", strings.ToUpper(pattern.Type)).Style(headingStyle),
 			tui.Text("  Pattern: %s", pattern.MessagePattern).Style(docStyle),
 			tui.Stack(causeViews...).Gap(0),
@@ -1101,7 +1105,8 @@ func printFuncDoc(name string, fn object.FuncSpec, titleStyle, headingStyle, nam
 	}
 
 	if fn.Returns != "" {
-		views = append(views,
+		views = append(
+			views,
 			tui.Text(""),
 			tui.Group(
 				tui.Text("Returns: ").Style(headingStyle),
@@ -1111,7 +1116,8 @@ func printFuncDoc(name string, fn object.FuncSpec, titleStyle, headingStyle, nam
 	}
 
 	if fn.Example != "" {
-		views = append(views,
+		views = append(
+			views,
 			tui.Text(""),
 			tui.Text("EXAMPLE").Style(headingStyle),
 			tui.Text("  %s", fn.Example).Style(nameStyle),

--- a/cmd/risor/eval_cmd_test.go
+++ b/cmd/risor/eval_cmd_test.go
@@ -575,7 +575,8 @@ func TestNewPrintBuiltin(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	result, err := fn.Call(context.Background(),
+	result, err := fn.Call(
+		context.Background(),
 		object.NewString("hello"),
 		object.NewInt(42),
 		object.NewFloat(3.14),

--- a/docs/direction/v3-notes.md
+++ b/docs/direction/v3-notes.md
@@ -1,0 +1,62 @@
+# v3 Notes
+
+A running list of changes to consider when planning a future v3 release.
+Items here are deliberately deferred — they would break v2 scripts or commit
+to implementation details we want flexibility to revisit.
+
+This file is intentionally informal. Promote items to a proper proposal in
+`docs/design/proposals/` when they're ready to be designed.
+
+## Error handling
+
+### Remove dependence on Go-specific error wrapping
+
+**Today (v2):** The `error()` builtin uses `fmt.Errorf` internally, so scripts
+can pass the `%w` verb to produce a wrapped error. `*Error.Equals` walks the
+resulting chain via `errors.Is` (added in v2.2.0) so wrapped sentinels match
+their descendants under `==`. Neither behavior is documented in the
+language reference — both are implementation details.
+
+**Concern:** Both `%w` and `errors.Is` are Go-specific. If Risor ever has a
+Rust or TypeScript implementation, the wrap-chain model doesn't translate
+cleanly. We do not want the script-level error semantics to require a
+specific host language's error machinery.
+
+**Direction for v3:**
+
+- Switch the `error()` builtin from `fmt.Errorf` to `fmt.Sprintf`, with
+  format-string validation that rejects unsupported verbs (`%w` in
+  particular) with a clear scripting error.
+- Reconsider what `==` should mean for errors. Options:
+  - Identity-only (errors are equal iff they are the same value).
+  - A portable "kind" model where errors carry a script-visible tag and
+    `==` compares tags (`err.kind == "not_exist"` or similar).
+  - Keep `errors.Is`-walking for errors produced by Go modules but disallow
+    script-level construction of wrap chains.
+- Drop the message-equality fallback in `*Error.Equals`. Two distinct errors
+  with the same formatted message are not the same error.
+
+**Compatibility plan:** This is a v3-only change. v2.2.0 leaves wrapping
+working and undocumented; the v2.2.0 CHANGELOG explicitly calls wrap
+mechanics "not part of the stable scripting API" so removing them in v3 is
+not a documented-API break.
+
+### Possible script-level introspection
+
+If we keep the wrap model in any form, scripts may want to inspect chains
+without going through `==`. Candidates:
+
+- `err.cause()` / `err.unwrap()` — exposes the immediate underlying error
+- `err.is(other)` — explicit chain check, one-directional, mirrors Go's
+  `errors.Is`
+- `err.kind` — a portable tag for categorizing errors
+
+We deliberately did **not** add any of these in v2.2.0 to keep the API
+surface small and to avoid committing to Go-shaped concepts that v3 might
+remove.
+
+## Other candidates
+
+Add items here as they come up. Keep entries short — a few sentences each,
+with a "concern" and a "direction" line. Anything that needs more than a
+paragraph or two should graduate to a proposal.

--- a/pkg/modules/regexp/regexp_object.go
+++ b/pkg/modules/regexp/regexp_object.go
@@ -79,7 +79,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 	switch name {
 	// Testing
 	case "test", "match":
-		return object.NewBuiltin("regexp.test",
+		return object.NewBuiltin(
+			"regexp.test",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) != 1 {
 					return nil, fmt.Errorf("regexp.test: expected 1 argument, got %d", len(args))
@@ -94,7 +95,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Finding first match
 	case "find":
-		return object.NewBuiltin("regexp.find",
+		return object.NewBuiltin(
+			"regexp.find",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) != 1 {
 					return nil, fmt.Errorf("regexp.find: expected 1 argument, got %d", len(args))
@@ -113,7 +115,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Finding all matches
 	case "find_all":
-		return object.NewBuiltin("regexp.find_all",
+		return object.NewBuiltin(
+			"regexp.find_all",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) < 1 || len(args) > 2 {
 					return nil, fmt.Errorf("regexp.find_all: expected 1-2 arguments, got %d", len(args))
@@ -140,7 +143,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Search for index
 	case "search":
-		return object.NewBuiltin("regexp.search",
+		return object.NewBuiltin(
+			"regexp.search",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) != 1 {
 					return nil, fmt.Errorf("regexp.search: expected 1 argument, got %d", len(args))
@@ -161,7 +165,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Capture groups (renamed from find_submatch)
 	case "groups":
-		return object.NewBuiltin("regexp.groups",
+		return object.NewBuiltin(
+			"regexp.groups",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) != 1 {
 					return nil, fmt.Errorf("regexp.groups: expected 1 argument, got %d", len(args))
@@ -184,7 +189,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// All matches with capture groups
 	case "find_all_groups":
-		return object.NewBuiltin("regexp.find_all_groups",
+		return object.NewBuiltin(
+			"regexp.find_all_groups",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) < 1 || len(args) > 2 {
 					return nil, fmt.Errorf("regexp.find_all_groups: expected 1-2 arguments, got %d", len(args))
@@ -216,7 +222,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Replace with optional count
 	case "replace":
-		return object.NewBuiltin("regexp.replace",
+		return object.NewBuiltin(
+			"regexp.replace",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) < 2 || len(args) > 3 {
 					return nil, fmt.Errorf("regexp.replace: expected 2-3 arguments, got %d", len(args))
@@ -259,7 +266,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Replace all (convenience method, same as replace with count=0)
 	case "replace_all":
-		return object.NewBuiltin("regexp.replace_all",
+		return object.NewBuiltin(
+			"regexp.replace_all",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) != 2 {
 					return nil, fmt.Errorf("regexp.replace_all: expected 2 arguments, got %d", len(args))
@@ -278,7 +286,8 @@ func (r *Regexp) GetAttr(name string) (object.Object, bool) {
 
 	// Split
 	case "split":
-		return object.NewBuiltin("regexp.split",
+		return object.NewBuiltin(
+			"regexp.split",
 			func(ctx context.Context, args ...object.Object) (object.Object, error) {
 				if len(args) < 1 || len(args) > 2 {
 					return nil, fmt.Errorf("regexp.split: expected 1-2 arguments, got %d", len(args))

--- a/pkg/object/args.go
+++ b/pkg/object/args.go
@@ -6,11 +6,13 @@ func Require(funcName string, count int, args []Object) *Error {
 		if count == 1 {
 			return NewError(ArgsErrorf(
 				"args error: %s() takes exactly 1 argument (%d given)",
-				funcName, nArgs))
+				funcName, nArgs,
+			))
 		}
 		return NewError(ArgsErrorf(
 			"args error: %s() takes exactly %d arguments (%d given)",
-			funcName, count, nArgs))
+			funcName, count, nArgs,
+		))
 	}
 	return nil
 }
@@ -20,11 +22,13 @@ func RequireRange(funcName string, min, max int, args []Object) *Error {
 	if nArgs < min {
 		return NewError(ArgsErrorf(
 			"args error: %s() takes at least %d %s (%d given)",
-			funcName, min, pluralize("argument", min > 1), nArgs))
+			funcName, min, pluralize("argument", min > 1), nArgs,
+		))
 	} else if nArgs > max {
 		return NewError(ArgsErrorf(
 			"args error: %s() takes at most %d %s (%d given)",
-			funcName, max, pluralize("argument", max > 1), nArgs))
+			funcName, max, pluralize("argument", max > 1), nArgs,
+		))
 	}
 	return nil
 }

--- a/pkg/object/error.go
+++ b/pkg/object/error.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/deepnoodle-ai/risor/v2/pkg/op"
@@ -166,6 +167,12 @@ func (e *Error) Equals(other Object) bool {
 	otherError, ok := other.(*Error)
 	if !ok {
 		return false
+	}
+	// Match wrapped sentinels in either direction, then fall back to message
+	// equality for script-created errors. The chain-walking is an
+	// implementation detail and may change; see docs/direction/v3-notes.md.
+	if errors.Is(e.err, otherError.err) || errors.Is(otherError.err, e.err) {
+		return true
 	}
 	return e.Message().Value() == otherError.Message().Value()
 }

--- a/pkg/object/error_test.go
+++ b/pkg/object/error_test.go
@@ -3,6 +3,7 @@ package object
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/deepnoodle-ai/wonton/assert"
@@ -16,6 +17,48 @@ func TestErrorEquals(t *testing.T) {
 	assert.Equal(t, e.Message().Value(), "a")
 	assert.True(t, e.Equals(other1))
 	assert.False(t, e.Equals(other2))
+}
+
+func TestErrorEqualsIdentity(t *testing.T) {
+	e := NewError(errors.New("boom"))
+	assert.True(t, e.Equals(e))
+}
+
+func TestErrorEqualsCrossType(t *testing.T) {
+	e := NewError(errors.New("boom"))
+	assert.False(t, e.Equals(NewString("boom")))
+}
+
+func TestErrorEqualsWrappedSentinel(t *testing.T) {
+	sentinel := errors.New("file does not exist")
+	wrapped := fmt.Errorf("read /tmp/x: %w", sentinel)
+
+	sentinelErr := NewError(sentinel)
+	wrappedErr := NewError(wrapped)
+
+	// == must match a wrapped error against its sentinel in both directions,
+	// since == is symmetric in script-land.
+	assert.True(t, wrappedErr.Equals(sentinelErr))
+	assert.True(t, sentinelErr.Equals(wrappedErr))
+}
+
+func TestErrorEqualsDeepChain(t *testing.T) {
+	sentinel := errors.New("not exist")
+	level1 := fmt.Errorf("open: %w", sentinel)
+	level2 := fmt.Errorf("read: %w", level1)
+	level3 := fmt.Errorf("parse: %w", level2)
+
+	sentinelErr := NewError(sentinel)
+	deepErr := NewError(level3)
+
+	assert.True(t, deepErr.Equals(sentinelErr))
+	assert.True(t, sentinelErr.Equals(deepErr))
+}
+
+func TestErrorEqualsUnrelatedSentinels(t *testing.T) {
+	a := NewError(errors.New("a"))
+	b := NewError(errors.New("b"))
+	assert.False(t, a.Equals(b))
 }
 
 func TestErrorCompareStr(t *testing.T) {

--- a/pkg/testing/runner.go
+++ b/pkg/testing/runner.go
@@ -182,7 +182,8 @@ func runTestFile(ctx context.Context, filename string, runRe *regexp.Regexp) *Fi
 
 	// Compile with standard builtins
 	env := risor.Builtins()
-	code, err := risor.Compile(ctx, string(source),
+	code, err := risor.Compile(
+		ctx, string(source),
 		risor.WithFilename(filename),
 		risor.WithEnv(env),
 	)

--- a/pkg/vm/typeregistry_test.go
+++ b/pkg/vm/typeregistry_test.go
@@ -49,7 +49,8 @@ func TestWithTypeRegistryOption(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Run with custom registry - the value should be doubled
-	vm, err := New(code,
+	vm, err := New(
+		code,
 		WithGlobals(map[string]any{"x": 21}),
 		WithTypeRegistry(customRegistry),
 	)
@@ -87,7 +88,8 @@ func TestTypeRegistryWithGlobalConversion(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Run with custom registry
-	vm, err := New(code,
+	vm, err := New(
+		code,
 		WithGlobals(map[string]any{"point": Point{X: 10, Y: 20}}),
 		WithTypeRegistry(registry),
 	)
@@ -120,7 +122,8 @@ func TestRisorValuerWithVM(t *testing.T) {
 	code, err := compiler.Compile(ast, &compiler.Config{GlobalNames: []string{"point"}})
 	assert.Nil(t, err)
 
-	vm, err := New(code,
+	vm, err := New(
+		code,
 		WithGlobals(map[string]any{"point": customPoint{X: 6, Y: 7}}),
 	)
 	assert.Nil(t, err)

--- a/pkg/vm/vm_test.go
+++ b/pkg/vm/vm_test.go
@@ -1013,7 +1013,8 @@ func TestContainers(t *testing.T) {
 		{`{"foo": "bar"}["foo"]`, object.NewString("bar")},
 		{`{foo: "bar"}["foo"]`, object.NewString("bar")},
 		{`[1, 2, 3, 4, 5].filter(function(x) { x > 3 })`, object.NewList(
-			[]object.Object{object.NewInt(4), object.NewInt(5)})},
+			[]object.Object{object.NewInt(4), object.NewInt(5)},
+		)},
 	}
 	runTests(t, tests)
 }
@@ -1073,7 +1074,8 @@ func TestQuicksort(t *testing.T) {
 				object.NewInt(3),
 				object.NewInt(5),
 				object.NewInt(10),
-			}))
+			},
+		))
 }
 
 func TestAndShortCircuit(t *testing.T) {

--- a/risor_test.go
+++ b/risor_test.go
@@ -244,7 +244,8 @@ func TestWithEnv(t *testing.T) {
 
 func TestWithEnvAdditive(t *testing.T) {
 	// Test that multiple WithEnv calls are additive
-	result, err := Eval(context.Background(), "x + y",
+	result, err := Eval(
+		context.Background(), "x + y",
 		WithEnv(map[string]any{"x": int64(10)}),
 		WithEnv(map[string]any{"y": int64(20)}),
 	)
@@ -254,7 +255,8 @@ func TestWithEnvAdditive(t *testing.T) {
 
 func TestWithEnvOverride(t *testing.T) {
 	// Test that later WithEnv calls override earlier ones
-	result, err := Eval(context.Background(), "x",
+	result, err := Eval(
+		context.Background(), "x",
 		WithEnv(map[string]any{"x": int64(10)}),
 		WithEnv(map[string]any{"x": int64(99)}),
 	)
@@ -369,7 +371,8 @@ func TestWithTypeRegistry(t *testing.T) {
 		Build()
 
 	// Use the custom registry
-	result, err := Eval(context.Background(), "point.x + point.y",
+	result, err := Eval(
+		context.Background(), "point.x + point.y",
 		WithEnv(map[string]any{"point": Point{X: 10, Y: 20}}),
 		WithTypeRegistry(registry),
 	)
@@ -388,7 +391,8 @@ func (c customValue) RisorValue() object.Object {
 
 func TestRisorValuerIntegration(t *testing.T) {
 	// Types implementing RisorValuer are automatically converted
-	result, err := Eval(context.Background(), "val",
+	result, err := Eval(
+		context.Background(), "val",
 		WithEnv(map[string]any{"val": customValue{data: "test"}}),
 	)
 	assert.Nil(t, err)
@@ -1404,7 +1408,8 @@ func TestWithEnvDuplicateKeysBehavior(t *testing.T) {
 	ctx := context.Background()
 
 	// Last value should win (documented behavior)
-	result, err := Eval(ctx, "x",
+	result, err := Eval(
+		ctx, "x",
 		WithEnv(map[string]any{"x": int64(1)}),
 		WithEnv(map[string]any{"x": int64(2)}),
 		WithEnv(map[string]any{"x": int64(3)}),


### PR DESCRIPTION
## Summary

- Fixes `==` so a wrapped error matches its underlying sentinel — e.g. `e == fs.err_not_exist` now works when `e` was returned from a module that wraps an inner error. Previous behavior compared only formatted message strings, so wrapped sentinels never matched.
- Purely additive: existing equality semantics (including message-equality for script-created errors) are preserved. No existing tests required changes.
- Adds `docs/direction/v3-notes.md` to track the longer-term plan to move off Go-specific error wrapping (`%w`, `errors.Is`) in a future major release.

Addresses [discussion #460](https://github.com/deepnoodle-ai/risor/discussions/460).

## Approach

`*Error.Equals` (`pkg/object/error.go`) now runs `errors.Is(a,b) || errors.Is(b,a)` ahead of the existing message-equality fallback. The bidirectional call is needed because Risor's `==` is symmetric, but Go's `errors.Is` is not — in practice one side is almost always a sentinel with no chain, so this resolves to a single chain walk.

Chain-walking is an implementation detail, not a language contract — the CHANGELOG and `v3-notes.md` both call out that error wrapping mechanics may change in a future major release. Deliberately did not add `err.is()`, `err.cause()`, or `err.unwrap()` to the public Error API to keep the surface area small and avoid committing to Go-shaped concepts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error equality comparisons now correctly match wrapped errors against their underlying chain instead of comparing only message strings.

* **Documentation**
  * Updated changelog with error equality fixes.
  * Added v3 direction notes outlining planned changes to error handling semantics.

* **Style**
  * Reformatted multi-line function calls and argument lists across multiple files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deepnoodle-ai/risor/pull/463)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->