### PR TITLE
Add Variadic() builder for methods with any number of arguments

### DIFF
--- a/cmd/risor/doc.go
+++ b/cmd/risor/doc.go
@@ -491,7 +491,7 @@ func docHandlerText(topic string) error {
 				tui.Text(""),
 				tui.Text("METHODS").Style(headingStyle),
 				tui.ForEach(t.Attrs, func(attr object.AttrSpec, _ int) tui.View {
-					sig := formatSignature(attr.Name, attr.Args)
+					sig := formatSignature(attr.Name, attr.DisplayArgs())
 					return tui.Group(
 						tui.Text("  .%s", sig).Style(nameStyle),
 						tui.Text("  %s", attr.Doc).Style(docStyle),
@@ -1003,7 +1003,7 @@ func typesMarkdown() string {
 			sb.WriteString("| Method | Description |\n")
 			sb.WriteString("|--------|-------------|\n")
 			for _, attr := range t.Attrs {
-				sig := formatSignature(attr.Name, attr.Args)
+				sig := formatSignature(attr.Name, attr.DisplayArgs())
 				sb.WriteString(fmt.Sprintf("| `.%s` | %s |\n", sig, attr.Doc))
 			}
 			sb.WriteString("\n")
@@ -1074,7 +1074,7 @@ func typeMarkdown(t object.TypeSpec) string {
 		sb.WriteString("| Method | Description |\n")
 		sb.WriteString("|--------|-------------|\n")
 		for _, attr := range t.Attrs {
-			sig := formatSignature(attr.Name, attr.Args)
+			sig := formatSignature(attr.Name, attr.DisplayArgs())
 			sb.WriteString(fmt.Sprintf("| `.%s` | %s |\n", sig, attr.Doc))
 		}
 	}

--- a/cmd/risor/repl.go
+++ b/cmd/risor/repl.go
@@ -519,8 +519,8 @@ func (app *replApp) handleCommand(input string) []tui.Cmd {
 		// Display methods with signatures
 		for _, attr := range attrs {
 			var sig string
-			if len(attr.Args) > 0 {
-				sig = fmt.Sprintf(".%s(%s)", attr.Name, strings.Join(attr.Args, ", "))
+			if args := attr.DisplayArgs(); len(args) > 0 {
+				sig = fmt.Sprintf(".%s(%s)", attr.Name, strings.Join(args, ", "))
 			} else {
 				sig = fmt.Sprintf(".%s()", attr.Name)
 			}

--- a/docs/design/method-registry.md
+++ b/docs/design/method-registry.md
@@ -73,6 +73,8 @@ func (r *AttrRegistry[T]) GetAttr(self T, name string) (Object, bool)
 func (b *AttrBuilder[T]) Doc(doc string) *AttrBuilder[T]
 func (b *AttrBuilder[T]) Arg(name string) *AttrBuilder[T]
 func (b *AttrBuilder[T]) Args(names ...string) *AttrBuilder[T]
+func (b *AttrBuilder[T]) OptionalArg(name string) *AttrBuilder[T]
+func (b *AttrBuilder[T]) Variadic(name string) *AttrBuilder[T]
 func (b *AttrBuilder[T]) Returns(typ string) *AttrBuilder[T]
 
 // Impl registers a callable method.
@@ -105,6 +107,28 @@ func init() {
             return s.ToLower(), nil
         })
 }
+```
+
+**Argument arities.** Argument count is validated automatically before `Impl`
+runs, so implementations can index `args` directly. A definition may declare:
+
+- `Arg(name)` / `Args(names...)` — required arguments (all must be provided).
+- `OptionalArg(name)` — an optional argument; must follow all required ones.
+- `Variadic(name)` — a final argument accepting any number of values (zero or
+  more). Required arguments may precede it, but nothing may follow it. Only one
+  variadic argument is allowed.
+
+```go
+// path.join(sep, *parts) — one required arg, then a variadic tail.
+pathAttrs.Define("join").
+    Doc("Join parts with a separator").
+    Arg("sep").
+    Variadic("parts").
+    Returns("string").
+    Impl(func(p *Path, ctx context.Context, args ...Object) (Object, error) {
+        // args[0] is sep; args[1:] are the (possibly empty) parts.
+        ...
+    })
 ```
 
 **Properties** (read-only attributes that return values directly):
@@ -196,27 +220,6 @@ func NewMethodRegistry[T any](typeName string) *AttrRegistry[T] {
 ```
 
 ## Future Extensions
-
-### Variadic Methods
-
-```go
-stringAttrs.Define("format").
-    Doc("Format with arguments").
-    Arg("template").
-    Variadic().
-    Returns("string").
-    Impl(...)
-```
-
-### Optional Arguments
-
-```go
-listAttrs.Define("pop").
-    Doc("Remove and return item").
-    OptionalArg("index", NewInt(-1)).
-    Returns("any").
-    Impl(...)
-```
 
 ### Writable Properties
 

--- a/pkg/object/attr.go
+++ b/pkg/object/attr.go
@@ -1,5 +1,7 @@
 package object
 
+import "slices"
+
 // AttrSpec describes an attribute available on an object.
 // This provides metadata for introspection, documentation, and tooling.
 type AttrSpec struct {
@@ -13,8 +15,25 @@ type AttrSpec struct {
 	// Empty for attributes that take no arguments.
 	Args []string
 
+	// Variadic reports whether the final argument accepts any number of
+	// values (zero or more). When true, the last entry in Args names the
+	// variadic parameter.
+	Variadic bool
+
 	// Returns describes the return type (e.g., "list", "string", "bool").
 	Returns string
+}
+
+// DisplayArgs returns the argument names formatted for display, with the final
+// argument suffixed with "..." when the attribute is variadic. The returned
+// slice is safe to modify; it never aliases Args.
+func (s AttrSpec) DisplayArgs() []string {
+	if !s.Variadic || len(s.Args) == 0 {
+		return slices.Clone(s.Args)
+	}
+	args := slices.Clone(s.Args)
+	args[len(args)-1] += "..."
+	return args
 }
 
 // FuncSpec describes a builtin function.

--- a/pkg/object/attr_registry.go
+++ b/pkg/object/attr_registry.go
@@ -3,6 +3,7 @@ package object
 import (
 	"context"
 	"fmt"
+	"math"
 	"slices"
 )
 
@@ -12,6 +13,7 @@ type AttrDef[T any] struct {
 	Spec       AttrSpec
 	IsProperty bool
 	MinArgs    int // Minimum required arguments (for optional arg support)
+	MaxArgs    int // Maximum allowed arguments (math.MaxInt for variadic methods)
 	// For methods:
 	MethodImpl func(self T, ctx context.Context, args ...Object) (Object, error)
 	// For properties:
@@ -31,7 +33,8 @@ type AttrBuilder[T any] struct {
 	name        string
 	doc         string
 	args        []string
-	optionalIdx int // Index where optional args start (0 means all required)
+	optionalIdx int  // Index where optional args start (0 means all required)
+	variadic    bool // Whether the final argument accepts any number of values
 	returns     string
 }
 
@@ -73,7 +76,7 @@ func (r *AttrRegistry[T]) GetAttr(self T, name string) (Object, bool) {
 
 	// Method: wrap in Builtin with argument validation
 	minArgs := attr.MinArgs
-	maxArgs := len(attr.Spec.Args)
+	maxArgs := attr.MaxArgs
 	fullName := r.typeName + "." + name
 	return &Builtin{
 		name: fullName,
@@ -93,8 +96,12 @@ func (b *AttrBuilder[T]) Doc(doc string) *AttrBuilder[T] {
 }
 
 // Arg adds a required argument by name (for methods).
-// Panics if called after OptionalArg (required args must come first).
+// Panics if called after OptionalArg or Variadic (required args must come first).
 func (b *AttrBuilder[T]) Arg(name string) *AttrBuilder[T] {
+	if b.variadic {
+		panic(fmt.Sprintf("%s.%s: required argument %q cannot follow a variadic argument",
+			b.registry.typeName, b.name, name))
+	}
 	if b.optionalIdx > 0 {
 		panic(fmt.Sprintf("%s.%s: required argument %q cannot follow optional arguments",
 			b.registry.typeName, b.name, name))
@@ -104,8 +111,12 @@ func (b *AttrBuilder[T]) Arg(name string) *AttrBuilder[T] {
 }
 
 // Args adds multiple required arguments (for methods).
-// Panics if called after OptionalArg (required args must come first).
+// Panics if called after OptionalArg or Variadic (required args must come first).
 func (b *AttrBuilder[T]) Args(names ...string) *AttrBuilder[T] {
+	if b.variadic {
+		panic(fmt.Sprintf("%s.%s: required arguments cannot follow a variadic argument",
+			b.registry.typeName, b.name))
+	}
 	if b.optionalIdx > 0 {
 		panic(fmt.Sprintf("%s.%s: required arguments cannot follow optional arguments",
 			b.registry.typeName, b.name))
@@ -116,11 +127,34 @@ func (b *AttrBuilder[T]) Args(names ...string) *AttrBuilder[T] {
 
 // OptionalArg adds an optional argument by name (for methods).
 // Optional args must come after all required args.
+// Panics if called after Variadic.
 func (b *AttrBuilder[T]) OptionalArg(name string) *AttrBuilder[T] {
+	if b.variadic {
+		panic(fmt.Sprintf("%s.%s: optional argument %q cannot follow a variadic argument",
+			b.registry.typeName, b.name, name))
+	}
 	if b.optionalIdx == 0 {
 		// First optional arg - mark where optional args start
 		b.optionalIdx = len(b.args) + 1 // +1 because we use 0 as "not set"
 	}
+	b.args = append(b.args, name)
+	return b
+}
+
+// Variadic adds a final argument that accepts any number of values (zero or
+// more). Required arguments (via Arg/Args) may precede it, but no further
+// arguments may be added afterward. Panics if called after OptionalArg or a
+// prior Variadic.
+func (b *AttrBuilder[T]) Variadic(name string) *AttrBuilder[T] {
+	if b.variadic {
+		panic(fmt.Sprintf("%s.%s: only one variadic argument is allowed",
+			b.registry.typeName, b.name))
+	}
+	if b.optionalIdx > 0 {
+		panic(fmt.Sprintf("%s.%s: variadic argument %q cannot follow optional arguments",
+			b.registry.typeName, b.name, name))
+	}
+	b.variadic = true
 	b.args = append(b.args, name)
 	return b
 }
@@ -140,17 +174,23 @@ func (b *AttrBuilder[T]) Impl(fn func(T, context.Context, ...Object) (Object, er
 		panic(fmt.Sprintf("%s: attribute %q already registered", r.typeName, b.name))
 	}
 	spec := AttrSpec{
-		Name:    b.name,
-		Doc:     b.doc,
-		Args:    b.args,
-		Returns: b.returns,
+		Name:     b.name,
+		Doc:      b.doc,
+		Args:     b.args,
+		Variadic: b.variadic,
+		Returns:  b.returns,
 	}
-	// Calculate minimum required args
+	// Calculate the allowed argument-count range.
 	minArgs := len(b.args)
 	if b.optionalIdx > 0 {
 		minArgs = b.optionalIdx - 1 // -1 because optionalIdx is 1-indexed
 	}
-	r.attrs[b.name] = AttrDef[T]{Spec: spec, MinArgs: minArgs, MethodImpl: fn}
+	maxArgs := len(b.args)
+	if b.variadic {
+		minArgs-- // the variadic parameter itself is not required
+		maxArgs = math.MaxInt
+	}
+	r.attrs[b.name] = AttrDef[T]{Spec: spec, MinArgs: minArgs, MaxArgs: maxArgs, MethodImpl: fn}
 	r.specs = append(r.specs, spec)
 }
 
@@ -187,6 +227,12 @@ func argsError(methodName string, expected, got int) error {
 func argsRangeError(methodName string, min, max, got int) error {
 	if min == max {
 		return argsError(methodName, min, got)
+	}
+	if max == math.MaxInt {
+		if min == 1 {
+			return fmt.Errorf("%s: expected at least 1 argument, got %d", methodName, got)
+		}
+		return fmt.Errorf("%s: expected at least %d arguments, got %d", methodName, min, got)
 	}
 	return fmt.Errorf("%s: expected %d to %d arguments, got %d", methodName, min, max, got)
 }

--- a/pkg/object/attr_registry_test.go
+++ b/pkg/object/attr_registry_test.go
@@ -147,6 +147,127 @@ func TestAttrRegistrySingleArg(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected 1 argument")
 }
 
+// TestAttrRegistryVariadic tests methods that accept any number of arguments.
+func TestAttrRegistryVariadic(t *testing.T) {
+	type testObj struct{}
+	registry := NewAttrRegistry[*testObj]("test")
+
+	// Pure variadic: zero or more args.
+	registry.Define("collect").
+		Variadic("items").
+		Impl(func(obj *testObj, ctx context.Context, args ...Object) (Object, error) {
+			return NewInt(int64(len(args))), nil
+		})
+
+	obj := &testObj{}
+	method, ok := registry.GetAttr(obj, "collect")
+	assert.True(t, ok)
+	builtin := method.(*Builtin)
+	ctx := context.Background()
+
+	// Zero args is allowed.
+	result, err := builtin.Call(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, result.(*Int).Value(), int64(0))
+
+	// Many args are allowed.
+	result, err = builtin.Call(ctx, NewInt(1), NewInt(2), NewInt(3))
+	assert.Nil(t, err)
+	assert.Equal(t, result.(*Int).Value(), int64(3))
+
+	// Spec metadata reflects the variadic tail.
+	spec, ok := FindAttr(registry.Specs(), "collect")
+	assert.True(t, ok)
+	assert.True(t, spec.Variadic)
+	assert.Equal(t, spec.Args, []string{"items"})
+	assert.Equal(t, spec.DisplayArgs(), []string{"items..."})
+}
+
+// TestAttrRegistryVariadicWithRequired tests required args preceding a variadic tail.
+func TestAttrRegistryVariadicWithRequired(t *testing.T) {
+	type testObj struct{}
+	registry := NewAttrRegistry[*testObj]("test")
+
+	// One required arg, then a variadic tail (min 1, unbounded max).
+	registry.Define("join").
+		Arg("sep").
+		Variadic("parts").
+		Impl(func(obj *testObj, ctx context.Context, args ...Object) (Object, error) {
+			return NewInt(int64(len(args))), nil
+		})
+
+	obj := &testObj{}
+	method, _ := registry.GetAttr(obj, "join")
+	builtin := method.(*Builtin)
+	ctx := context.Background()
+
+	// Just the required arg is allowed (zero variadic values).
+	result, err := builtin.Call(ctx, NewString(","))
+	assert.Nil(t, err)
+	assert.Equal(t, result.(*Int).Value(), int64(1))
+
+	// Required arg plus extra values.
+	result, err = builtin.Call(ctx, NewString(","), NewInt(1), NewInt(2))
+	assert.Nil(t, err)
+	assert.Equal(t, result.(*Int).Value(), int64(3))
+
+	// Missing the required arg is an error.
+	_, err = builtin.Call(ctx)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "expected at least 1 argument")
+
+	spec, ok := FindAttr(registry.Specs(), "join")
+	assert.True(t, ok)
+	assert.True(t, spec.Variadic)
+	assert.Equal(t, spec.DisplayArgs(), []string{"sep", "parts..."})
+}
+
+// TestAttrRegistryVariadicAtLeastPlural tests the plural "at least N" message.
+func TestAttrRegistryVariadicAtLeastPlural(t *testing.T) {
+	type testObj struct{}
+	registry := NewAttrRegistry[*testObj]("test")
+
+	registry.Define("f").
+		Args("a", "b").
+		Variadic("rest").
+		Impl(func(obj *testObj, ctx context.Context, args ...Object) (Object, error) {
+			return Nil, nil
+		})
+
+	obj := &testObj{}
+	method, _ := registry.GetAttr(obj, "f")
+	builtin := method.(*Builtin)
+
+	_, err := builtin.Call(context.Background(), NewInt(1))
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "expected at least 2 arguments")
+}
+
+// TestAttrRegistryVariadicOrdering tests the builder ordering panics.
+func TestAttrRegistryVariadicOrdering(t *testing.T) {
+	type testObj struct{}
+
+	// Required arg cannot follow a variadic.
+	assert.Panics(t, func() {
+		NewAttrRegistry[*testObj]("test").Define("bad").Variadic("rest").Arg("x")
+	})
+
+	// Optional arg cannot follow a variadic.
+	assert.Panics(t, func() {
+		NewAttrRegistry[*testObj]("test").Define("bad").Variadic("rest").OptionalArg("x")
+	})
+
+	// Variadic cannot follow an optional arg.
+	assert.Panics(t, func() {
+		NewAttrRegistry[*testObj]("test").Define("bad").OptionalArg("x").Variadic("rest")
+	})
+
+	// Only one variadic is allowed.
+	assert.Panics(t, func() {
+		NewAttrRegistry[*testObj]("test").Define("bad").Variadic("a").Variadic("b")
+	})
+}
+
 // TestArgHelper tests the Arg helper function.
 func TestArgHelper(t *testing.T) {
 	args := []Object{NewInt(42), NewString("hello")}


### PR DESCRIPTION
Closes #466.

## Problem

`AttrRegistry` could not express a method that takes a variable number of arguments. The builder offered required args (`Arg`/`Args`), zero-or-one (`OptionalArg`), and zero args — but the maximum was always pinned to the number of declared arg names, because `GetAttr` derived it directly:

```go
maxArgs := len(attr.Spec.Args)
```

So methods like `join(sep, *parts)`, `format(template, *args)`, or `max(*values)` on a custom object type were impossible to declare through the registry.

## Change

Adds `AttrBuilder.Variadic(name)`: a final argument that accepts **zero or more** values.

```go
pathAttrs.Define("join").
    Arg("sep").
    Variadic("parts").   // args[0] = sep, args[1:] = parts (possibly empty)
    Impl(...)
```

- Required args (`Arg`/`Args`) may precede a variadic; nothing may follow it, and only one variadic is allowed (all enforced with panics, matching the existing required-after-optional guard).
- Went with **unbounded** rather than the issue's suggested "cap at 64" — the args slice is already bounded by the actual call, so an arbitrary cap adds a failure mode with no real safety benefit.
- Named it `Variadic(name)` rather than `OptionalArgs(name)` for clarity about the semantics; `name` is used for signature display.

### Implementation notes

- `AttrDef` now stores an explicit `MaxArgs` (`math.MaxInt` for variadic) instead of recomputing from `len(Spec.Args)`.
- `argsRangeError` reports `expected at least N argument(s)` for the unbounded case.
- `AttrSpec` gains a `Variadic bool` field plus a `DisplayArgs()` helper so `risor doc` and the REPL `:methods` view render the tail as `name...`.
- Updated `docs/design/method-registry.md` (documented `Variadic`/`OptionalArg`, moved them out of "Future Extensions").

## Tests

New cases in `attr_registry_test.go` cover pure variadic (0..N), required-args-then-variadic (min enforced, unbounded max), the singular/plural "at least N" error messages, and the four builder-ordering panics. Full suite passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)