### PR TITLE
Add memory limiting guide and review of issue #473

### DIFF
--- a/docs/guides/memory-limits.md
+++ b/docs/guides/memory-limits.md
@@ -1,0 +1,561 @@
+# Limiting Memory in Untrusted Scripts
+
+Risor bounds instruction count (`WithMaxSteps`) and wall-clock time
+(`WithTimeout`). It does not bound allocation, and it has no `WithMaxMemory`.
+A single instruction can allocate gigabytes:
+
+```go
+// runs fine, returns a result, allocates 5.4 GB
+risor.Eval(ctx, `len(list(range(50000000)))`,
+    risor.WithMaxSteps(1000),
+    risor.WithEnv(risor.Builtins()))
+```
+
+That is not a problem when you trust the script. It matters when you don't, and
+this guide is for that case: you want to run scripts you didn't write, in your
+own process, without letting one of them take the process down.
+
+## Start here: bound it outside the process
+
+**The only way to actually guarantee a memory bound today is to put the script
+inside something the operating system can kill.** Nothing you build with
+Risor's API gives you that guarantee, including everything in this guide.
+Reach for an external boundary first, and treat the in-process techniques below
+as a second layer rather than a substitute.
+
+The options, roughly in order of how much work they are:
+
+- **AWS Lambda**, or an equivalent per-invocation runtime on any cloud. If
+  you're already deployed in a cloud this is usually the least effort for the
+  most safety. You get a hard memory ceiling per invocation, a hard timeout,
+  and a fresh process each time, so a script that misbehaves takes down its own
+  invocation and nothing else. Configure the function's memory to what your
+  scripts legitimately need and let the platform enforce it.
+- **A container with a memory limit.** `--memory` on Docker, or `resources.limits.memory`
+  on Kubernetes. The kernel OOM-kills the container rather than your host.
+- **A subprocess with an rlimit.** `RLIMIT_AS` or `RLIMIT_DATA` via
+  `syscall.Setrlimit` before `exec`. Cheapest to adopt if you're already on a
+  single box, and it keeps the blast radius to one child process.
+
+All three degrade safely when you get something wrong, which is the property
+that matters. The in-process approach does not: when it fails, it fails by
+taking down the process that was supposed to be doing the limiting.
+
+## Read this first, if you're staying in-process
+
+**What you can build with today's API is real but incomplete.** It gives you a
+hard cap on the operations a script is most likely to abuse. It does not give
+you a guarantee that the process cannot be pushed out of memory. The gaps are
+specific and listed under [What this does not cover](#what-this-does-not-cover).
+Read that section before you rely on any of this.
+
+The rest of this guide is worth your time when a script exceeding its budget is
+a bug to be reported rather than a security incident, or when you want a fast
+in-process check in front of an external boundary so that ordinary abuse fails
+cleanly instead of costing you a killed container.
+
+## The idea
+
+Risor v2 has no loop keywords. There is no `for`, no `while`, no `for-in`.
+Iteration exists only through callbacks (`.map`, `.each`, `.filter`,
+`.reduce`) and through recursion, and both of those need a function definition.
+
+So if you disallow function definitions, every script runs top to bottom
+exactly once. Its instruction count is bounded by the length of its source, and
+its total allocation is the sum over a fixed number of operations. At that
+point, capping each individual operation caps the whole program.
+
+That is what makes the rest of this guide work. Without it you are trying to
+bound an unbounded number of operations, which the current API cannot do.
+
+Three layers, each useful on its own:
+
+1. Start from an empty environment and add back only what you need.
+2. Turn off the syntax you don't need, starting with function definitions.
+3. Route `+` and method calls through a budget that checks sizes before
+   allocating.
+
+## Layer 1: start from an empty environment
+
+The environment is empty by default. `risor.Builtins()` is opt-in, so the first
+and cheapest thing you can do is not call it.
+
+```go
+all := risor.Builtins()
+env := map[string]any{
+    "len":     all["len"],
+    "string":  all["string"],
+    "int":     all["int"],
+    "float":   all["float"],
+    "bool":    all["bool"],
+    "type":    all["type"],
+    "sprintf": all["sprintf"],
+}
+risor.Eval(ctx, src, risor.WithEnv(env))
+```
+
+Leaving out `list`, `range`, `sorted`, `chunk` and `encode` removes the worst
+cases outright. `list(range(N))` is the single most expensive thing a script
+can do, because every element of a list is an interface header plus a boxed
+value, roughly 100× the per-element cost of a string.
+
+One thing this does **not** do: it does not remove type methods.
+`"a".repeat(1000000000)` still works no matter what is in the environment,
+because methods resolve through `GetAttr` on the object rather than through the
+environment. Layer 3 is what handles those.
+
+## Layer 2: turn off syntax you don't need
+
+```go
+syntax := risor.SyntaxConfig{
+    DisallowFuncDef:   true,  // the important one: no callbacks, no recursion
+    DisallowReturn:    true,
+    DisallowSpread:    true,  // [...a, ...a] grows a list with no call to intercept
+    DisallowTemplates: true,  // `${a}${a}` concatenates with no call to intercept
+    DisallowPipe:      true,
+    DisallowTryCatch:  true,
+}
+risor.Eval(ctx, src, risor.WithEnv(env), risor.WithSyntax(syntax))
+```
+
+`DisallowFuncDef` is the one that matters most, for the reason above.
+
+`DisallowSpread` and `DisallowTemplates` matter because those two constructs
+allocate inside VM instructions, with no function call anywhere for Layer 3 to
+wrap. Turning them off in the grammar is the only way to bound them from
+outside the library. Without `DisallowSpread`, six lines of nested spreads
+allocate about 1 GB.
+
+Don't reach for the presets here. `ExpressionOnly` looks like it should help
+and doesn't: it still allows operators and calls, so `"aaaa".repeat(n) + "b"`
+passes straight through. It restricts grammar, not cost.
+
+## Layer 3: budget the operations that remain
+
+`WithTransform` runs between parsing and compiling, and `pkg/ast` is fully
+exported with settable fields. That is enough to rewrite `a + b` into
+`__add(a, b)` and `x.m(args...)` into `__method(x, "m", args...)`, where both
+guards are functions you control.
+
+The pieces below concatenate into a single file.
+
+### The budget
+
+Charge **before** allocating. Charging afterwards tells you a script went over,
+but the memory has already been handed to the runtime, and one operation is
+enough to get the process killed.
+
+```go
+// Budget is a memory allowance for a single script execution. It is not safe
+// for concurrent use; give each execution its own.
+type Budget struct {
+    limit int64
+    used  int64
+}
+
+func NewBudget(limit int64) *Budget { return &Budget{limit: limit} }
+
+func (b *Budget) Reserve(n int64) error {
+    if n < 0 || b.used+n > b.limit {
+        return fmt.Errorf("memory limit exceeded: %d bytes requested, %d of %d used",
+            n, b.used, b.limit)
+    }
+    b.used += n
+    return nil
+}
+```
+
+### Measuring a value
+
+`Sizeof` needs caps on how much work it will do. List literals can share
+structure, so `a = [a, a]` repeated thirty times builds a tree of 2^30 elements
+in almost no memory. A naive recursive size function walks all of them and
+hangs, which turns your safeguard into the vulnerability.
+
+```go
+const (
+    maxVisits = 10_000 // nodes Sizeof will look at before giving up
+    maxDepth  = 32     // how deep it will nest
+)
+
+// ErrTooLarge means Sizeof gave up. Treat it as "does not fit".
+var ErrTooLarge = errors.New("value too large or too deeply nested to measure")
+
+func Sizeof(o object.Object) (int64, error) {
+    visits := maxVisits
+    return sizeof(o, 0, &visits)
+}
+
+func sizeof(o object.Object, depth int, visits *int) (int64, error) {
+    if depth > maxDepth || *visits <= 0 {
+        return 0, ErrTooLarge
+    }
+    *visits--
+
+    switch o := o.(type) {
+    case *object.String:
+        return int64(len(o.Value())) + 16, nil
+    case *object.Bytes:
+        return int64(len(o.Value())) + 24, nil
+    case *object.List:
+        total := int64(24)
+        for _, item := range o.Value() {
+            n, err := sizeof(item, depth+1, visits)
+            if err != nil {
+                return 0, err
+            }
+            total += 16 + n
+        }
+        return total, nil
+    case *object.Map:
+        total := int64(48)
+        for k, v := range o.Value() {
+            n, err := sizeof(v, depth+1, visits)
+            if err != nil {
+                return 0, err
+            }
+            total += int64(len(k)) + 32 + n
+        }
+        return total, nil
+    default:
+        return 16, nil // scalars: close enough
+    }
+}
+```
+
+These are estimates, not exact figures. That is fine for a budget, as long as
+you set the limit with headroom.
+
+### The transform
+
+Note that method calls parse as `ast.ObjectCall`, not as
+`ast.Call{Fun: *ast.GetAttr}`. Assuming the latter is an easy way to write a
+transform that silently misses every method call.
+
+```go
+func Transform(program *ast.Program) (*ast.Program, error) {
+    rewrite(program)
+    return program, nil
+}
+
+func rewrite(n ast.Node) ast.Node {
+    if n == nil {
+        return nil
+    }
+    v := reflect.ValueOf(n)
+    if v.Kind() != reflect.Ptr || v.IsNil() || v.Elem().Kind() != reflect.Struct {
+        return n
+    }
+
+    // Recurse into every exported field that can hold a node.
+    s := v.Elem()
+    for i := 0; i < s.NumField(); i++ {
+        f := s.Field(i)
+        if !f.CanSet() {
+            continue
+        }
+        switch f.Kind() {
+        case reflect.Interface:
+            if !f.IsNil() {
+                if child, ok := f.Interface().(ast.Node); ok {
+                    replaceIn(f, rewrite(child))
+                }
+            }
+        case reflect.Ptr:
+            if !f.IsNil() {
+                if child, ok := f.Interface().(ast.Node); ok {
+                    rewrite(child)
+                }
+            }
+        case reflect.Slice:
+            for j := 0; j < f.Len(); j++ {
+                e := f.Index(j)
+                if e.Kind() == reflect.Interface && !e.IsNil() {
+                    if child, ok := e.Interface().(ast.Node); ok {
+                        replaceIn(e, rewrite(child))
+                    }
+                } else if e.Kind() == reflect.Ptr && !e.IsNil() {
+                    if child, ok := e.Interface().(ast.Node); ok {
+                        rewrite(child)
+                    }
+                }
+            }
+        }
+    }
+
+    // Then rewrite this node itself.
+    switch x := n.(type) {
+    case *ast.Infix:
+        if x.Op == "+" {
+            return &ast.Call{
+                Fun:    &ast.Ident{NamePos: x.OpPos, Name: "__add"},
+                Lparen: x.OpPos,
+                Args:   []ast.Node{x.X, x.Y},
+                Rparen: x.OpPos,
+            }
+        }
+    case *ast.ObjectCall:
+        name, ok := x.Call.Fun.(*ast.Ident)
+        if !ok {
+            return n
+        }
+        args := []ast.Node{x.X, &ast.String{Value: name.Name}}
+        args = append(args, x.Call.Args...)
+        return &ast.Call{
+            Fun:    &ast.Ident{NamePos: x.Period, Name: "__method"},
+            Lparen: x.Period,
+            Args:   args,
+            Rparen: x.Call.Rparen,
+        }
+    }
+    return n
+}
+
+func replaceIn(field reflect.Value, replacement ast.Node) {
+    if replacement == nil {
+        return
+    }
+    if rv := reflect.TypeOf(replacement); rv.AssignableTo(field.Type()) {
+        field.Set(reflect.ValueOf(replacement))
+    }
+}
+```
+
+### The guards
+
+`__add` checks operand sizes before the concatenation happens. `__method`
+handles all type methods through one wrapper, because `GetAttr` returns a
+`*Builtin` that already satisfies `object.Callable`.
+
+Methods whose output size is a known function of their inputs get checked up
+front. `repeat` is the one that matters. Everything else charges afterwards,
+which is acceptable only because its inputs are already inside the budget.
+
+```go
+func Guards(b *Budget) map[string]any {
+    return map[string]any{
+        "__add":    object.NewBuiltin("__add", guardAdd(b)),
+        "__method": object.NewBuiltin("__method", guardMethod(b)),
+    }
+}
+
+func guardAdd(b *Budget) func(context.Context, ...object.Object) (object.Object, error) {
+    return func(ctx context.Context, args ...object.Object) (object.Object, error) {
+        if len(args) != 2 {
+            return nil, errors.New("__add: expected 2 arguments")
+        }
+        left, right := args[0], args[1]
+
+        // Only the growable types need checking; int + int cannot run away.
+        switch left.(type) {
+        case *object.String, *object.Bytes, *object.List:
+            ln, err := Sizeof(left)
+            if err != nil {
+                return nil, err
+            }
+            rn, err := Sizeof(right)
+            if err != nil {
+                return nil, err
+            }
+            if err := b.Reserve(ln + rn); err != nil {
+                return nil, err
+            }
+        }
+        return object.BinaryOp(op.Add, left, right)
+    }
+}
+
+func guardMethod(b *Budget) func(context.Context, ...object.Object) (object.Object, error) {
+    return func(ctx context.Context, args ...object.Object) (object.Object, error) {
+        if len(args) < 2 {
+            return nil, errors.New("__method: expected a receiver and a method name")
+        }
+        self := args[0]
+        name, ok := args[1].(*object.String)
+        if !ok {
+            return nil, errors.New("__method: method name must be a string")
+        }
+        rest := args[2:]
+
+        // repeat multiplies its receiver, so its output size is known up front.
+        checked := false
+        if name.Value() == "repeat" && len(rest) == 1 {
+            if count, ok := rest[0].(*object.Int); ok {
+                n, err := Sizeof(self)
+                if err != nil {
+                    return nil, err
+                }
+                if err := b.Reserve(n * count.Value()); err != nil {
+                    return nil, err
+                }
+                checked = true
+            }
+        }
+
+        attr, found := self.GetAttr(name.Value())
+        if !found {
+            return nil, fmt.Errorf("attribute %q not found on %s", name.Value(), self.Type())
+        }
+        fn, ok := attr.(object.Callable)
+        if !ok {
+            return nil, fmt.Errorf("attribute %q is not callable", name.Value())
+        }
+
+        result, err := fn.Call(ctx, rest...)
+        if err != nil {
+            return nil, err
+        }
+        if checked {
+            return result, nil
+        }
+        n, err := Sizeof(result)
+        if err != nil {
+            return nil, err
+        }
+        return result, b.Reserve(n)
+    }
+}
+```
+
+### Wrapping your own builtins
+
+The transform rewrites operators and method calls. It does **not** rewrite
+plain function calls, so anything you put in the environment needs wrapping
+yourself.
+
+```go
+func Wrap(b *Budget, name string, fn object.Callable) object.Object {
+    return object.NewBuiltin(name, func(ctx context.Context, args ...object.Object) (object.Object, error) {
+        result, err := fn.Call(ctx, args...)
+        if err != nil {
+            return nil, err
+        }
+        n, err := Sizeof(result)
+        if err != nil {
+            return nil, err
+        }
+        return result, b.Reserve(n)
+    })
+}
+```
+
+## Putting it together
+
+```go
+func Eval(ctx context.Context, src string, env map[string]any, limit int64) (any, error) {
+    b := NewBudget(limit)
+
+    full := make(map[string]any, len(env)+2)
+    for k, v := range env {
+        if fn, ok := v.(object.Callable); ok {
+            full[k] = Wrap(b, k, fn)
+            continue
+        }
+        full[k] = v
+    }
+    for k, v := range Guards(b) {
+        full[k] = v
+    }
+
+    return risor.Eval(ctx, src,
+        risor.WithEnv(full),
+        risor.WithSyntax(risor.SyntaxConfig{
+            DisallowFuncDef:   true,
+            DisallowReturn:    true,
+            DisallowSpread:    true,
+            DisallowTemplates: true,
+            DisallowPipe:      true,
+            DisallowTryCatch:  true,
+        }),
+        risor.WithTransform(risor.TransformerFunc(Transform)),
+        risor.WithMaxSteps(10_000),
+    )
+}
+```
+
+Imports: `context`, `errors`, `fmt`, `reflect`, plus `risor`, `pkg/ast`,
+`pkg/object` and `pkg/op`.
+
+### What this measures
+
+Against a 10 MB budget, with the environment from Layer 1:
+
+| Script | Peak allocation | Result |
+| --- | ---: | --- |
+| `code + ": " + street + " " + num` | 0 MB | `DE: Hauptstrasse 42` |
+| `"  Germany  ".trim_space().to_upper()` | 0 MB | `GERMANY` |
+| `"a,b,c".split(",")[1]` | 0 MB | `b` |
+| Chained `+` doubling ten times per line | 8 MB | refused at the budget |
+| `len("a".repeat(1000000000))` | 0 MB | refused before allocating |
+| `[...a, ...a, ...a]` | 0 MB | rejected at validation |
+| `` len(`${a}${a}`) `` | 0 MB | rejected at validation |
+| `[1,2,3].map(x => x * 2)` | 0 MB | rejected at validation |
+
+Without any of this, the chained `+` case allocates 572 MB and the `repeat`
+case about 950 MB.
+
+Good numbers, and still not a guarantee. Everything in that table is a case
+somebody thought to test. The section below is the list of cases where this
+approach is known to fall short, which is why it belongs behind an external
+boundary rather than in place of one.
+
+## What this does not cover
+
+Set expectations accordingly. These are the gaps, and none of them can be
+closed from outside the library. Each is a reason to keep the container,
+Lambda, or rlimit from the top of this guide in place.
+
+**Shared list structure.** `a = [a, a]` repeated thirty times is a few lines of
+source, allocates almost nothing, and reports `len(a) == 2`. The list literal
+is built inside a VM instruction, so there is no call for the transform to
+wrap. It stays harmless until something expands it, which is why you should not
+put `string`, `sorted`, `encode` or `chunk` over lists into the environment. If
+you need `string()` on arbitrary values, this approach is not enough for you.
+
+**Methods that charge after the fact.** Only `repeat` has its output size
+checked before the work happens. Any method whose output size isn't a cheap
+function of its inputs allocates first and charges second. In practice its
+inputs are already inside the budget, so this costs you a constant factor
+rather than leaving an unbounded hole, but it does mean the peak is higher than
+the number you set.
+
+**`Sizeof` is an estimate.** It ignores Go's allocator overhead, slice capacity
+beyond length, and map bucket overhead. Set your limit well below the memory
+you can actually afford to lose.
+
+**`WithTimeout` is not a hard bound.** Independently of memory, a builtin whose
+runtime grows faster than its input can run past the deadline. The VM sets a
+halt flag from a goroutine but only reads it between instructions, so Go code
+running inside a builtin cannot be interrupted. `string()` over the shared
+structure above will run for minutes under a two-second timeout.
+
+**The transform is coupled to AST node shapes.** If a node type is added to
+`pkg/ast` in a future release, the rewrite may silently stop covering some
+construct. Write a test that asserts your guards actually fire on every
+construct you care about, and re-run it when you upgrade.
+
+**Nothing here bounds the Go side.** Any function you expose can allocate
+whatever it likes before your wrapper ever sees the result. Wrapping charges
+for what comes back, not for what happened inside.
+
+## Summary
+
+The two layers do different jobs, and you want both.
+
+An **external boundary** is the only thing that actually guarantees a bound. It
+covers the gaps above and the ones nobody has found yet, because it doesn't
+depend on anyone having enumerated them. If you're in a cloud already, AWS
+Lambda or an equivalent per-invocation runtime is usually the cheapest way to
+get there. Otherwise, a container memory limit or a subprocess with `RLIMIT_AS`.
+
+The **in-process budget** in this guide gives you a fast, cheap failure for
+ordinary abuse, with a clear error you can log and hand back to whoever wrote
+the script. That's worth having in front of the boundary, since a refused
+operation is much nicer to operate than a killed container. It is not worth
+having instead of one.
+
+## See also
+
+- [`docs/reviews/2026_08_memory_bounding.md`](../reviews/2026_08_memory_bounding.md)
+  for the measurements behind this guide and what it would take to support
+  memory limits in the library itself.

--- a/docs/reviews/2026_08_memory_bounding.md
+++ b/docs/reviews/2026_08_memory_bounding.md
@@ -1,0 +1,498 @@
+# Memory Bounding
+
+This came out of [issue #473](https://github.com/deepnoodle-ai/risor/issues/473), which
+showed that a Risor script can allocate several gigabytes while staying well inside
+`WithMaxSteps` and `WithTimeout`.
+
+Memory bounding was never a Risor design goal, so this isn't a defect in ordinary
+embedding. It's the reason that running fully untrusted scripts in-process, which is
+what the issue asks for, is harder than the existing limits make it look. This document
+maps out how much harder, how far you can get today, and what it would cost if we
+decided to support the use case properly.
+
+Every number below was measured against commit `a263ecc` using
+`runtime.MemStats.TotalAlloc` deltas, on Go 1.26.2, darwin/arm64.
+
+## The short version
+
+Risor limits how many instructions run and how long they run for. It doesn't limit how
+much work a single instruction does, and a single instruction can allocate gigabytes.
+`list(range(50000000))` allocates 5.4 GB under a 1000-step limit. That's fine when you
+trust the script. It's the whole problem when you don't.
+
+You can get where the issue wants to be today without changing Risor, and for the
+spreadsheet-mapping case it describes the answer is complete rather than partial. What
+makes it work is that Risor v2 has no loop keywords. Turn off function definitions and
+every script runs top to bottom exactly once, at which point capping each individual
+operation caps the whole program. Measured: peak allocation on the repro drops from
+572 MB to 8 MB, and to zero on `"a".repeat(1000000000)`, while ordinary field-mapping
+expressions keep working. Section 3 has the recipe.
+
+If we did want to support this in the library, the piece that covers the issue is
+roughly 150 lines. Section 4 covers what it would take beyond that to offer a real
+`WithMaxMemory`.
+
+One genuine bug did fall out of the investigation, and it's unrelated to the design
+question: `WithTimeout` can be escaped entirely. That's in §1.2.
+
+---
+
+## 1. Where the memory goes
+
+The use case in the issue is a template engine where the script is untrusted but the
+data is controlled: mapping spreadsheet cells to normalized values, like turning the
+country name "Germany" into the code "DE". It has to run in-process next to a larger
+pipeline, so sandboxing it in a container or a Lambda isn't available.
+
+`WithMaxSteps` and `WithTimeout` bound instructions and wall-clock time, which is what
+they claim to do. Neither says anything about allocation. The tables below are really a
+measurement of how much room that leaves.
+
+### 1.1 How much one script can allocate
+
+Every row runs with `WithMaxSteps(1000)` and `risor.Builtins()`. Every one of them
+returns a result instead of an error.
+
+| What it does | Script | Allocated |
+| --- | --- | ---: |
+| Materialize a range | `len(list(range(50000000)))` | **5,468 MB** |
+| Spread a list into itself | `[...a,...a,...a]` × 6 levels | 966 MB |
+| Chain string concatenation | the script from the issue | 572 MB |
+| Sort a big list | `sorted(list(range(5000000)))` | 555 MB |
+| Repeat a string | `"a".repeat(500000000)` | 476 MB |
+| Repeat bytes | `bytes("a").repeat(500000000)` | 476 MB |
+| Interpolate a big string | `` `${a}${a}…` `` where `a` is 1 MB | multiplies |
+
+Two things worth pulling out.
+
+Lists cost about 100× more per element than strings do. Each element is an interface
+header plus a boxed `*Int`, which measured at roughly 109 bytes per element against
+1 byte per character for a string. That's why the range case dwarfs everything else.
+
+And `list(range(50000000))` allocates 5.4 GB from one instruction. If you want a single
+sentence for why step counting doesn't help here, that's it.
+
+### 1.2 A real bug found along the way: `WithTimeout` can be escaped
+
+Everything above is a limit Risor never promised. This one is different. `WithTimeout`
+is documented as returning `context.DeadlineExceeded` when the timeout is exceeded, and
+there are scripts where it doesn't return at all.
+
+Risor v2 has no loop statements (see §3.3), but list literals can share structure, so a
+few lines of source can build a huge tree in almost no memory:
+
+```risor
+let a = [1]
+a = [a, a]   // repeated 30 times
+// ...
+len(string(a))
+```
+
+Building that costs about 0 MB and 60 instructions. `len(a)` is 2. But rendering it with
+`string()` walks 2^30 elements inside one builtin call:
+
+```
+WithTimeout(2s) + ctx deadline 2s  ->  had not returned after 20s
+```
+
+The cause is structural. `start()` spawns a goroutine that sets `vm.halt`
+(`pkg/vm/vm.go:285-290`), but the flag is only read at the top of the eval loop
+(`pkg/vm/vm.go:501`), so Go code running inside a builtin can't be interrupted. Any
+builtin whose runtime grows faster than its input escapes both `maxSteps` and
+`WithTimeout`.
+
+This deserves its own issue, since it's a divergence from documented behavior rather
+than a design gap. It does share a root cause with #473, though: the VM counts
+instructions, not work. Phase 4 in §4 fixes it.
+
+---
+
+## 2. Why you can't bound this from outside today
+
+Four separate reasons, any one of which would be enough on its own.
+
+**The operator interface has nowhere to put a budget.**
+
+```go
+// pkg/object/object.go:95
+RunOperation(opType op.BinaryOpType, right Object) (Object, error)
+```
+
+No `context.Context`, no VM handle, no allocator. Nothing you can attach a per-execution
+limit to, and so nothing that reaches `String.runOperationString`
+(`pkg/object/string.go:239`), the four lines that produce the reported gigabyte.
+
+**There's no single place allocation happens.** It's spread across ten VM opcodes
+(`BinaryOp`, `BuildString`, `BuildList`, `BuildMap`, `ListAppend`, `ListExtend`,
+`MapMerge`, `MapSet`, `Slice`, `BinarySubscr`), 82 registered type attributes
+(`ls pkg/object/*.go | grep -v _test | xargs grep -h '\.Define(' | wc -l`), 25 builtins
+and 3 modules. Each one calls `object.NewString`, `NewList`, `NewMap` or `NewBytes`
+directly.
+
+**You can't swap in your own string type.** `object.Object` is an open interface, but the
+VM type-switches on the concrete `*object.String` for map keys (`vm.go:840`, `vm.go:930`)
+and template joins (`vm.go:1022`). A size-aware replacement would break at those sites.
+
+**Step counting is batched, and it looks backwards.** `maxSteps` is checked every
+`contextCheckInterval` instructions, 1000 by default (`vm.go:509-537`). Even with a
+correct cost model, the check happens after the allocation.
+
+### One distinction that decides everything below
+
+Every approach in this document either:
+
+- **checks before allocating** — work out the output size from the inputs, refuse if it
+  doesn't fit; or
+- **allocates and then charges** — do the work, measure the result, fail afterwards.
+
+Only the first bounds peak memory. Charging afterwards limits how much you accumulate
+across many operations, but it can't stop one operation from spiking, and one spike is
+enough to get the process OOM-killed. Keep this in mind for everything that follows.
+
+---
+
+## 3. What you can do today, with the library as-is
+
+More than I expected going in. Risor already ships the pieces needed to run untrusted
+scripts under a memory budget; they're just not labelled that way, and none of the
+documentation connects them. For the use case in the issue this adds up to a real
+answer, not a partial one.
+
+### 3.1 What the shipped options give you
+
+| Option | What it limits | Hard limit? |
+| --- | --- | --- |
+| `WithMaxSteps` | instruction count | batched ±1000, and no model of work |
+| `WithTimeout` | wall clock | no, escapable inside a builtin (§1.2) |
+| `WithMaxStackDepth` | value stack and frame depth | yes |
+| `WithEnv` | what the script can reach | yes |
+| `WithSyntax` | what grammar is allowed | yes |
+| `WithValidator` | rejects any AST you don't like | yes |
+| `WithTransform` | rewrites the AST before compiling | yes |
+
+The bottom four do the real work. The top two are the ones people reach for first.
+
+### 3.2 Cut down the environment
+
+The environment is empty by default, and `risor.Builtins()` is opt-in. This is the
+biggest win available for the least effort:
+
+```go
+env := map[string]any{
+    "len": ..., "string": ..., "int": ..., "sprintf": ...,
+}
+risor.Eval(ctx, src, risor.WithEnv(env))  // not risor.Builtins()
+```
+
+Leaving out `list`, `range`, `sorted`, `chunk` and `encode` removes the 5,468 MB and
+555 MB cases outright, along with several others.
+
+One catch: this does not remove type *methods*. `"a".repeat(n)` still works no matter
+what's in the environment, because methods resolve through `GetAttr` on the object
+rather than through the environment. You need §3.4 for those.
+
+### 3.3 Restrict the grammar, and the fact that makes this work
+
+**Risor v2 has no loop statements.** The keyword table
+(`internal/token/token.go:129`) has no `for`, `while` or `range`, and I confirmed that
+`for`, `while`, `for-in` and `range` statements are all parse errors. Iteration only
+exists through callbacks (`.map`, `.each`, `.filter`, `.reduce`) and recursion. Both of
+those need a function definition.
+
+So `DisallowFuncDef` makes every script run top to bottom exactly once. Instruction
+count becomes proportional to the length of the source, and total allocation becomes the
+sum over a fixed, source-bounded number of operations. That's what turns a leaky wrapper
+into a real bound: once the program can't loop, capping each individual operation caps
+the program. I verified that `.each(x => ...)`, `.map(x => ...)` and recursion are all
+rejected at validation time under `DisallowFuncDef`.
+
+`SyntaxConfig` also closes two holes that nothing else can reach, because they happen
+inside VM instructions with no function call to wrap:
+
+- `DisallowSpread` kills the 966 MB list-spread case
+- `DisallowTemplates` kills the string-interpolation multiplier
+
+Skip the presets, though. `ExpressionOnly` looks like it ought to help and does nothing
+here. It still allows operators and calls, so `"aaaa".repeat(n) + "b"` sails straight
+through. It restricts grammar, not cost.
+
+### 3.4 Rewrite the AST and check sizes in the guards
+
+`pkg/ast` is fully exported with plain settable struct fields, and `WithTransform` runs
+between parsing and compiling. That's enough to route `+` and every method call through
+functions you control.
+
+```go
+switch x := n.(type) {
+case *ast.Infix:
+    if x.Op == "+" {
+        return &ast.Call{
+            Fun:  &ast.Ident{NamePos: x.OpPos, Name: "__add"},
+            Args: []ast.Node{x.X, x.Y},
+        }
+    }
+case *ast.ObjectCall:   // note: NOT ast.Call{Fun: *ast.GetAttr}, which is easy to assume
+    name := x.Call.Fun.(*ast.Ident)
+    args := append([]ast.Node{x.X, &ast.String{Value: name.Name}}, x.Call.Args...)
+    return &ast.Call{
+        Fun:  &ast.Ident{NamePos: x.Period, Name: "__method"},
+        Args: args,
+    }
+}
+```
+
+A reflection-based walker covers the whole tree in about 60 lines, since every field is
+an exported `Expr`, `Node` or slice of them.
+
+The guards need to check sizes *before* the allocation happens:
+
+```go
+env["__add"] = object.NewBuiltin("__add", func(ctx context.Context, args ...object.Object) (object.Object, error) {
+    a, b := args[0], args[1]
+    switch a.(type) {
+    case *object.String, *object.Bytes, *object.List:
+        if err := budget.reserve(sizeOf(a) + sizeOf(b)); err != nil {
+            return nil, err          // refused BEFORE object.BinaryOp allocates
+        }
+    }
+    return object.BinaryOp(op.Add, a, b)
+})
+
+env["__method"] = object.NewBuiltin("__method", func(ctx context.Context, args ...object.Object) (object.Object, error) {
+    self, name, rest := args[0], args[1].(*object.String).Value(), args[2:]
+
+    // methods that take a multiplier get checked up front
+    if name == "repeat" && len(rest) == 1 {
+        if n, ok := rest[0].(*object.Int); ok {
+            if err := budget.reserve(sizeOf(self) * n.Value()); err != nil {
+                return nil, err
+            }
+        }
+    }
+
+    attr, found := self.GetAttr(name)
+    if !found {
+        return nil, fmt.Errorf("attribute %q not found on %s", name, self.Type())
+    }
+    res, err := attr.(object.Callable).Call(ctx, rest...)
+    if err != nil {
+        return nil, err
+    }
+    if name != "repeat" {
+        return res, budget.reserve(sizeOf(res))  // everything else charges afterwards
+    }
+    return res, nil
+})
+```
+
+One `__method` wrapper covers all 82 type methods, because `GetAttr` hands back a
+`*Builtin` that already satisfies `object.Callable`.
+
+Worth knowing: plain builtin calls, meaning `ast.Call` with an `*ast.Ident`, are not
+rewritten by this transform. You have to wrap those yourself when you build the
+environment. Since you're building it anyway, that's a loop over a map rather than a
+problem.
+
+### 3.5 What the whole setup measures
+
+Configuration: hand-built environment, `DisallowFuncDef` plus `DisallowSpread`,
+`DisallowTemplates`, `DisallowPipe`, `DisallowTryCatch` and `DisallowReturn`, the `+`
+and method transform with size checks, 10 MB budget.
+
+| Case | Before | Peak after | What happens |
+| --- | ---: | ---: | --- |
+| The repro from #473 | 572 MB | **8 MB** | stopped at the budget |
+| `"a".repeat(1000000000)` | ~950 MB | **0 MB** | refused before allocating |
+| `bytes("a").repeat(…)` | 476 MB | 0 MB | `bytes` isn't in the environment |
+| List spread | 966 MB | 0 MB | rejected at validation |
+| Template string | multiplies | 0 MB | rejected at validation |
+| `code + ": " + street + " " + num` | — | 0 MB | works, returns `DE: Hauptstrasse 42` |
+
+The zero rows come from checking before allocating. This is a genuine cap on peak memory
+for scripts that can't loop, with no changes to Risor.
+
+### 3.6 What's still open
+
+Four things I couldn't close from outside.
+
+**Shared list structure.** `a = [a, a]` repeated 30 times is a handful of lines, about
+0 MB allocated, and `len(a) == 2`. `op.BuildList` happens inside a VM instruction, so
+there's no call to wrap. It stays harmless right up until something expands it, so don't
+whitelist `string`, `sorted`, `encode` or `chunk` over lists. If you need `string()` on
+arbitrary values, you need the library change.
+
+**Your size function is itself a hazard.** A naive recursive `sizeOf` over the tree
+above is 2^30 operations and hangs, which turns your guard into the vulnerability. Give
+it a budget of nodes to visit and a depth cap, and have it return "too big" instead of a
+number when it hits either.
+
+**Methods that charge afterwards.** Anything whose output size isn't a cheap function of
+its inputs still allocates first. In practice the inputs are already inside the budget,
+so this costs you a constant factor rather than leaving a hole.
+
+**The transform is coupled to AST node shapes.** `ast.ObjectCall` versus
+`ast.Call{Fun: GetAttr}` already cost me a debugging cycle, and a node type added
+upstream would be a silent gap. Worth a test that asserts the rewrite fires on every
+construct that allocates.
+
+`WithTimeout` also stays soft (§1.2), independently of any of this.
+
+---
+
+## 4. What it would cost to support this in the library
+
+Everything here is optional. Risor works fine today for embedders who trust the scripts
+they run, and each phase below is a step toward a different product: one that can also
+host scripts you don't trust. They're ordered so that stopping after any of them leaves
+something coherent.
+
+### Phase 1: check sizes at the opcode boundary
+
+About 150 lines, no break to the public API, and it covers the case in the issue.
+
+```go
+// vm.go:683
+case op.BinaryOp:
+    opType := op.BinaryOpType(vm.fetch())
+    b := vm.pop()
+    a := vm.pop()
+    if err := vm.reserveForBinaryOp(opType, a, b); err != nil {   // new
+        ...
+    }
+    result, err := object.BinaryOp(opType, a, b)
+```
+
+Add `maxBytes` and `bytesUsed` to `VirtualMachine` along with a `WithMaxMemory(n int64)`
+option, add a shallow `object.Sizeof(Object) int64` with the visit cap from §3.6, and do
+the same check at all ten allocating opcodes.
+
+No interface changes and nothing ripples into the object package. It covers both the
+concatenation and spread cases with no spike, and it's the workable form of the first
+suggestion in the issue: charge the cost before doing the work, rather than converting
+it into steps and noticing 1000 instructions later.
+
+Of the four phases this is the one with the best ratio of coverage to cost, so it's the
+one to weigh first.
+
+### Phase 2: methods and builtins
+
+`callObject` (`vm.go:1448`) is the one place every `object.Callable` goes through, and it
+has a `ctx`. Put the budget in the context; the pattern already exists as
+`object.WithCallFunc` (`pkg/object/context_values.go`). Then two levels:
+
+Charge afterwards at `callObject` for all 82 methods and 25 builtins. One place, cheap,
+catches accumulation.
+
+Check up front inside the six operations that multiply their input: `string.repeat`,
+`bytes.repeat`, `list()` over a range (`builtins.go:59`), `chunk`, `sorted` and `encode`.
+Output size is a cheap function of the inputs in each of them, so the check is easy and
+it removes the spike.
+
+### Phase 3: decide what the number means
+
+The plumbing is easy. Deciding what a memory limit actually measures is the hard part.
+
+**Charge cumulatively and never give anything back.** Safe and deterministic. Too
+restrictive for a script that creates and discards a lot of temporaries, except that
+without loops the churn is bounded by source length anyway, so for straight-line scripts
+this stays within a small constant factor of what's actually live. It only becomes a
+problem once callbacks are back on the table. That makes it a much more reasonable
+default for v2 than it would be in a language with `for`.
+
+**Track what's actually live.** What you'd want, but Go's GC gives you no hook, and
+refcounting every object is a non-starter.
+
+**Walk the VM roots and measure.** The middle path, and the part of this that would take
+actual design work. Risor's VM has an explicit set of roots: `vm.stack[:sp+1]`,
+`vm.globals`, the locals and free cells in `vm.frames[:fp+1]`, `vm.tmp`, and the
+constants in loaded code (`vm.go:40-115`). So charge cumulatively, and when the counter
+hits the ceiling, walk those roots and reset the counter to what's genuinely retained.
+The walk needs a visited set, both because closures and cells form cycles and because
+shared structure would otherwise be counted twice. Since it only runs at the ceiling,
+the cost doesn't show up in normal execution.
+
+Call it 200 to 300 lines. This is the difference between shipping a `WithMaxMemory` that
+means what it says and shipping one that's really a cap on total allocations. The
+explicit root set is what makes it tractable in Risor and impractical in most languages.
+
+### Phase 4: make long-running builtins interruptible
+
+Fixes §1.2. Pass `ctx` into the recursive walkers that can run away (`Inspect`,
+`MarshalJSON`, `Equals`, `Compare`, `Sizeof`) and check it periodically, or cap how many
+nodes they'll visit. Without this, `WithTimeout` stays soft no matter what happens with
+memory.
+
+### What each phase gets you
+
+| | as-is | +P1 | +P2 | +P3 | +P4 |
+| --- | :-: | :-: | :-: | :-: | :-: |
+| Bound `+`, spread, templates | via syntax config | ✅ | ✅ | ✅ | ✅ |
+| Bound methods and builtins | wrapper, charged after | — | ✅ | ✅ | ✅ |
+| Bound allocation inside opcodes | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Limit reflects what's live | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Safe to allow callbacks | ❌ | partial | partial | ✅ | ✅ |
+| Hard wall-clock bound | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `string()` safe on shared structure | ❌ | ❌ | ❌ | ✅ | ✅ |
+
+---
+
+## 5. Recommendations
+
+### 5.1 If you need this today
+
+1. Build the environment by hand instead of calling `risor.Builtins()`. Whitelist what
+   you need, something like `len`, `string`, `int`, `float`, `bool`, `type` and
+   `sprintf`, and wrap each one so it charges the budget.
+2. Set `WithSyntax` with `DisallowFuncDef`, `DisallowSpread`, `DisallowTemplates`,
+   `DisallowPipe`, `DisallowTryCatch` and `DisallowReturn`. `DisallowFuncDef` is the one
+   that matters most, since it's what stops the script from looping.
+3. Add a `WithTransform` that rewrites `+` and `ObjectCall`, checking operand sizes in
+   `__add` and the multiplier in `repeat` before the work happens.
+4. Keep `WithMaxSteps` and `WithTimeout` as a backstop.
+5. Cap `sizeOf` by visit count and depth.
+
+Measured across every case I could find: peak allocation between 0 and 8 MB against a
+10 MB budget, with normal field-mapping expressions unaffected. Nothing to fork, nothing
+to merge upstream, and no change to how the surrounding pipeline is deployed.
+
+### 5.2 For Risor
+
+**Fix §1.2, and file it separately.** That one is a divergence from what `WithTimeout`
+documents, so it stands on its own regardless of what we decide about memory. Phase 4
+covers it.
+
+**Say plainly what the limits do and don't cover.** The opening line of #473 was that
+`WithMaxSteps` and `WithTimeout` suggest execution can be bounded. That's a fair reading
+of the option names, and the answer is that they bound two specific things and not
+allocation. Worth stating in the option docs whether or not anything else changes, since
+the reading in #473 is the one most embedders will make.
+
+**Phase 1 is worth considering on its own merits.** 150 lines and no API break, and it
+would turn "Risor doesn't bound memory" into "Risor bounds memory at the operations
+where it's cheap to know the answer." Whether that's worth doing is a scope question
+about what Risor is for, not a bug to be fixed. I lean yes, because it's small and
+because it makes the untrusted-script story go from "not really" to "yes, with care."
+
+**The earlier "not feasible" answer holds up better than it might look.** It's right for
+cumulative-only accounting, which is the obvious way in. Two things I didn't expect
+change the picture: v2 has no loop statements, which makes cumulative accounting far
+more workable than it would otherwise be, and the VM's explicit root set makes the
+walk-and-measure approach practical. Neither is visible without going looking.
+
+**The guide may help more than any of this.** The pieces already exist and compose well
+(`WithEnv`, `WithSyntax`, `WithValidator`, `WithTransform`), but nothing told an embedder
+that `DisallowFuncDef` is what makes resource limits tractable in the first place. Most
+people who want what #473 asks for can have it today and don't know it. §3 of this
+document is now written up as
+[`docs/guides/memory-limits.md`](../guides/memory-limits.md), with working code and an
+explicit list of what it doesn't cover.
+
+---
+
+## 6. Reproducing any of this
+
+The measurement setup is easy to rebuild: a module with a `replace` directive pointing
+at this repo, `runtime.ReadMemStats` around each `risor.Eval`, and the scripts from the
+tables above. For the `DisallowFuncDef` finding, assert that
+`[1,2,3].each(x => print(x))` fails validation while `len("a".repeat(100000000))` still
+succeeds. That second half is exactly why the transform layer is needed too.


### PR DESCRIPTION
Docs only, no code changes. Comes out of #473, where a script allocated several gigabytes while staying well inside `WithMaxSteps` and `WithTimeout`.

Memory bounding was never a Risor design goal, so this isn't framed as a defect in ordinary embedding. It's framed as the reason running fully untrusted scripts in-process is harder than the existing limits make it look.

## `docs/guides/memory-limits.md`

A practical guide for embedders who need this today.

It leads with the part that matters most: the only way to actually guarantee a memory bound is an external boundary. AWS Lambda or an equivalent per-invocation runtime if you're already in a cloud, otherwise a container memory limit or a subprocess with `RLIMIT_AS`. Everything in-process is a second layer, not a substitute.

After that it covers what Risor already supports:

1. Start from an empty environment and add back only what you need
2. Turn off syntax you don't need, starting with `DisallowFuncDef`
3. Route `+` and method calls through a budget that checks sizes **before** allocating

It closes with an explicit list of six things the approach does not cover and why none of them can be closed from outside the library.

Every Go block in the guide was extracted from the finished markdown, compiled, and run. Measured against a 10 MB budget:

| Script | Peak | Result |
| --- | ---: | --- |
| `code + ": " + street + " " + num` | 0 MB | `DE: Hauptstrasse 42` |
| `"  Germany  ".trim_space().to_upper()` | 0 MB | `GERMANY` |
| chained `+` doubling per line | 8 MB | refused at budget (572 MB unguarded) |
| `len("a".repeat(1000000000))` | 0 MB | refused before allocating (~950 MB unguarded) |
| `[1,2,3].map(x => x * 2)` | 0 MB | rejected at validation |

## `docs/reviews/2026_08_memory_bounding.md`

New `docs/reviews/` directory. Records the measurements behind the guide, why the current API can't bound this from outside, and what supporting memory limits in the library would cost across four optional phases. No README in the new directory yet; happy to add one if you want a stated convention.

## Two findings worth a look

**Risor v2 has no loop keywords.** No `for`, `while`, or `for-in`; iteration only exists through callbacks and recursion, both of which need a function definition. So `DisallowFuncDef` makes every script straight-line, which is what makes per-operation limits meaningful at all. The guide now depends on this behavior, so a test asserting iteration is unreachable under `DisallowFuncDef` would be worth having.

**`WithTimeout` can be escaped.** Unrelated to memory and a genuine divergence from documented behavior. List literals share structure, so `a = [a, a]` thirty times builds a 2^30-element tree in ~0 MB and ~60 instructions. Rendering it with `string()` walks the whole thing inside one builtin call. Measured: `WithTimeout(2s)` plus a 2s context deadline, and eval had not returned after 20 seconds. The halt flag is set by a goroutine (`vm.go:285-290`) but only read at the top of the eval loop (`vm.go:501`), so Go code inside a builtin can't be interrupted. This deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a guide for limiting memory usage when running untrusted scripts.
  - Documented layered safeguards, including restricted environments, syntax controls, allocation budgets, size checks, guarded operations, and wrapped built-ins.
  - Added measured behavior, configuration guidance, limitations, and known gaps.
  - Added an investigation covering memory allocation, timeout limitations, mitigation options, and recommended implementation phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->