### PR TITLE
Prepare v2.2.0 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,11 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w
+      - >-
+        -s -w
+        -X main.version={{ .Version }}
+        -X main.commit={{ .Commit }}
+        -X main.date={{ .Date }}
     goos:
       - linux
       - windows
@@ -21,9 +25,10 @@ builds:
     main: .
 archives:
   - id: "standard"
-    builds:
+    ids:
       - "standard"
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -33,7 +38,8 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -44,18 +50,30 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
-brews:
-  - skip_upload: false
+homebrew_casks:
+  - name: risor
+    ids:
+      - "standard"
+    binaries:
+      - risor
+    skip_upload: false
     repository:
       owner: deepnoodle-ai
       name: homebrew-risor
     commit_author:
       name: Curtis Myzie
       email: info@cmds.dev
-    directory: Formula
+    directory: Casks
+    url:
+      verified: github.com/deepnoodle-ai/risor/
     homepage: "https://github.com/deepnoodle-ai/risor"
     description: "An embedded scripting language for Go projects"
-    license: "Apache-2.0"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/risor"]
+          end
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-17
+
+### Added
+
+- **Variadic method definitions** — Go embedders can use
+  `AttrBuilder.Variadic(name)` to define object methods that accept zero or more
+  trailing arguments (#467).
+
+### Changed
+
+- The VS Code extension now requires VS Code 1.91 or newer and uses the current
+  language client and TypeScript toolchain (#475).
+
 ### Fixed
 
 - Error equality (`==`) now matches a wrapped error against its underlying
   sentinel, so `err == fs.err_not_exist` works when `err` was returned from a
   module that wraps an inner error. The previous behavior compared only error
-  message strings, so wrapped sentinels never matched.
+  message strings, so wrapped sentinels never matched (#463).
+- Closures with more than eight local variables now preserve their captured
+  values when a VM frame is reused for another function call (#462).
+
+### Documentation
+
+- Added a practical guide to memory limits, including isolation boundaries,
+  in-process safeguards, and the limits of timeout and step-count controls
+  (#474).
+
+### Dependencies
+
+- Updated Go and VS Code extension dependencies, clearing the repository's
+  known dependency security alerts at release preparation time (#475).
 
 ### Notes
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export GIT_REVISION=$(shell git rev-parse --short HEAD)
 export VERSION=$(shell git describe --tags --always --dirty | sed 's/^v//')
 
-# Packages to exclude from testing (examples, benchmarks)
-TEST_EXCLUDE := examples tests/benchmarks
+# Packages to exclude from testing (examples, benchmarks, JavaScript dependencies)
+TEST_EXCLUDE := examples tests/benchmarks vscode
 
 .PHONY: test
 test:
@@ -66,6 +66,11 @@ format:
 .PHONY: release
 release:
 	goreleaser release --clean -p 2
+
+.PHONY: release-snapshot
+release-snapshot:
+	goreleaser check
+	goreleaser release --snapshot --clean -p 2
 
 .PHONY: generate
 generate:

--- a/cmd/risor-lsp/go.mod
+++ b/cmd/risor-lsp/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/deepnoodle-ai/risor/v2 => ../..
 
 require (
-	github.com/deepnoodle-ai/risor/v2 v2.1.0
+	github.com/deepnoodle-ai/risor/v2 v2.2.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 	github.com/jdbaldry/go-language-server-protocol v0.0.0-20211013214444-3022da0884b2
 	github.com/rs/zerolog v1.35.1

--- a/cmd/risor/doc_types.go
+++ b/cmd/risor/doc_types.go
@@ -1,9 +1,12 @@
 package main
 
-import "github.com/deepnoodle-ai/risor/v2/pkg/object"
+import (
+	"github.com/deepnoodle-ai/risor/v2/pkg/docs"
+	"github.com/deepnoodle-ai/risor/v2/pkg/object"
+)
 
 // Version is the current Risor version.
-const docVersion = "2.0.0"
+const docVersion = docs.Version
 
 // QuickReference provides a concise overview of Risor for quick orientation.
 type QuickReference struct {

--- a/cmd/risor/go.mod
+++ b/cmd/risor/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/deepnoodle-ai/risor/v2 => ../..
 
 require (
-	github.com/deepnoodle-ai/risor/v2 v2.1.0
+	github.com/deepnoodle-ai/risor/v2 v2.2.0
 	github.com/deepnoodle-ai/wonton v0.0.37
 )
 

--- a/docs/design/llm_discovery.md
+++ b/docs/design/llm_discovery.md
@@ -111,7 +111,7 @@ Level 2: Deep Dive (risor doc <topic>)
 ```json
 {
   "risor": {
-    "version": "2.0.0",
+    "version": "2.2.0",
     "description": "Fast embedded scripting language for Go",
     "execution_model": "source → lexer → parser → compiler → bytecode → vm"
   },

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -4,19 +4,57 @@
 
 - `goreleaser` installed (`brew install goreleaser`)
 - `GITHUB_TOKEN` env var with repo access (used by GoReleaser to create the
-  GitHub release and push the Homebrew formula)
+  GitHub release and push the Homebrew cask)
 - Docker with `buildx` (only needed for Docker image publishing)
 
 ## Release Process
 
-### 1. Tag the release
+### 1. Prepare and verify the release
+
+Choose the next semantic version, then prepare a pull request that:
+
+- Moves the accumulated `CHANGELOG.md` entries from `Unreleased` into a dated
+  version section.
+- Updates `pkg/docs.Version` and any nested `go.mod` references to the new
+  version.
+
+Run the full release gate from a clean worktree:
 
 ```bash
-git tag v2.x.x
-git push origin v2.x.x
+make test
+make generate
+make format
+git diff --exit-code
+make release-snapshot
+git diff --exit-code
 ```
 
-### 2. Run GoReleaser
+`release-snapshot` exercises the GoReleaser configuration and builds the same
+archives locally without publishing them. Confirm the snapshot binary reports a
+generated version rather than `dev`:
+
+```bash
+./dist/standard_darwin_arm64_v8.0/risor version
+```
+
+The exact snapshot path varies by operating system and architecture. Merge the
+release-preparation pull request and wait for `main` CI to pass before tagging.
+
+### 2. Tag the exact release commit
+
+Synchronize a clean local `main`, then use the checked-in helper:
+
+```bash
+git switch main
+git pull --ff-only origin main
+scripts/tag.sh v2.x.x
+```
+
+The helper refuses dirty worktrees, non-`main` branches, commits that differ
+from `origin/main`, and existing tags. Risor v2 publishes one repository tag;
+the CLI archives are built from `cmd/risor` by GoReleaser.
+
+### 3. Run GoReleaser
 
 ```bash
 make release
@@ -27,11 +65,15 @@ This runs `goreleaser release --clean -p 2`, which:
 - Builds cross-platform binaries (linux/darwin amd64+arm64, windows amd64)
 - Creates tar.gz archives (zip for windows) with checksums
 - Creates the GitHub release at `deepnoodle-ai/risor`
-- Updates the Homebrew formula at `deepnoodle-ai/homebrew-risor`
+- Updates the Homebrew cask at `deepnoodle-ai/homebrew-risor`
 
 Configuration: `.goreleaser.yaml`
 
-### 3. Publish Docker images (optional)
+Verify the published GitHub release is neither a draft nor a prerelease, its
+archives match `checksums.txt`, an extracted binary reports the release version,
+and the Homebrew cask points to the new tag and checksums.
+
+### 4. Publish Docker images (optional)
 
 ```bash
 make docker-build
@@ -45,28 +87,30 @@ This pushes multi-arch images (amd64, arm64) to Docker Hub:
 
 The version is derived automatically from `git describe --tags`.
 
+After publishing, inspect the `latest`, version, and git-revision manifests on
+Docker Hub and confirm that both amd64 and arm64 images are present.
+
 ## Homebrew
 
 The Homebrew tap is at
 [deepnoodle-ai/homebrew-risor](https://github.com/deepnoodle-ai/homebrew-risor).
 
-GoReleaser auto-updates `Formula/risor.rb` on each release. Users install with:
+GoReleaser auto-updates `Casks/risor.rb` on each release. Users install with:
 
 ```bash
-brew install deepnoodle-ai/risor/risor
+brew install --cask deepnoodle-ai/risor/risor
 ```
 
-### Versioned formulas
+The v2.2.0 release is the first cask-based release. After its cask is published
+and verified, remove the obsolete unversioned `Formula/risor.rb` from the tap so
+plain `brew install` cannot select the stale v2.1.0 formula. Preserve
+`Formula/risor@1.rb` for v1 users.
 
-When a major version introduces breaking changes, preserve the previous version
-as a versioned formula before releasing:
+### Preserving a previous major version
 
-1. Clone the tap: `git clone https://github.com/deepnoodle-ai/homebrew-risor.git`
-2. Copy `Formula/risor.rb` to `Formula/risor@<major>.rb`
-3. Rename the class from `Risor` to `RisorAT<major>` (Homebrew convention)
-4. Commit and push the versioned formula
-5. Return to the main risor repo, tag the new release, and run `make release`
-   (GoReleaser will overwrite `risor.rb` with the new version)
+Before a future breaking major release, copy the current `Casks/risor.rb` to a
+versioned cask such as `Casks/risor@2.rb`, change its token to `risor@2`, and
+commit it to the tap before GoReleaser replaces the unversioned cask.
 
 Users can pin to the old version:
 
@@ -76,4 +120,12 @@ brew install deepnoodle-ai/risor/risor@1
 
 The `risor@1` formula was created for the v1-to-v2 transition. Its download URLs
 point to the `risor-io/risor` GitHub org (the original home of the project). The
-main `risor` formula points to `deepnoodle-ai/risor`.
+stable `risor` cask points to `deepnoodle-ai/risor`.
+
+## VS Code extension
+
+The VS Code extension has its own version and is not published by `make
+release`. To release it, bump the version in `vscode/package.json`, compile and
+package it, then publish it separately with `make extension-publish`. Do not run
+that target as part of a Risor library release unless an extension release is
+intended.

--- a/examples/go/concurrent_vms/go.mod
+++ b/examples/go/concurrent_vms/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
-require github.com/deepnoodle-ai/risor/v2 v2.1.0
+require github.com/deepnoodle-ai/risor/v2 v2.2.0
 
 require (
 	github.com/deepnoodle-ai/wonton v0.0.37 // indirect

--- a/examples/go/custom_env/go.mod
+++ b/examples/go/custom_env/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
-require github.com/deepnoodle-ai/risor/v2 v2.1.0
+require github.com/deepnoodle-ai/risor/v2 v2.2.0
 
 require (
 	github.com/deepnoodle-ai/wonton v0.0.37 // indirect

--- a/examples/go/error_handling/go.mod
+++ b/examples/go/error_handling/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
-require github.com/deepnoodle-ai/risor/v2 v2.1.0
+require github.com/deepnoodle-ai/risor/v2 v2.2.0
 
 require (
 	github.com/deepnoodle-ai/wonton v0.0.37 // indirect

--- a/examples/go/expression_eval/go.mod
+++ b/examples/go/expression_eval/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
-require github.com/deepnoodle-ai/risor/v2 v2.1.0
+require github.com/deepnoodle-ai/risor/v2 v2.2.0
 
 require (
 	github.com/deepnoodle-ai/wonton v0.0.37 // indirect

--- a/examples/go/struct/go.mod
+++ b/examples/go/struct/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
 require (
-	github.com/deepnoodle-ai/risor/v2 v2.1.0
+	github.com/deepnoodle-ai/risor/v2 v2.2.0
 	github.com/fatih/color v1.19.0
 )
 

--- a/examples/go/tetra3d/go.mod
+++ b/examples/go/tetra3d/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/deepnoodle-ai/risor/v2 => ../../..
 
 require (
-	github.com/deepnoodle-ai/risor/v2 v2.1.0
+	github.com/deepnoodle-ai/risor/v2 v2.2.0
 	github.com/solarlune/tetra3d v0.18.0
 )
 

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -68,7 +68,7 @@ func (d *Documentation) Data() any {
 }
 
 // Version is the current Risor version.
-const Version = "2.0.0"
+const Version = "2.2.0"
 
 // docsRisorInfo provides basic Risor information.
 type docsRisorInfo struct {

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -1,16 +1,56 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-VERSION=$1
+VERSION=${1:-}
 
-if [ -z "$VERSION" ]; then
-    echo "Usage: tag.sh <version>"
+if [[ $# -ne 1 || ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "Usage: scripts/tag.sh v<major>.<minor>.<patch>" >&2
+    exit 2
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Refusing to tag a dirty worktree." >&2
     exit 1
 fi
 
-git tag $VERSION
-git tag cmd/risor/$VERSION
+git fetch origin main --prune --tags
 
-git push origin $VERSION
-git push origin cmd/risor/$VERSION
+if [[ "$(git branch --show-current)" != "main" ]]; then
+    echo "Refusing to tag outside the main branch." >&2
+    exit 1
+fi
+
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+    echo "Refusing to tag: local main is not exactly origin/main." >&2
+    exit 1
+fi
+
+RELEASE_VERSION=${VERSION#v}
+
+if ! git grep --quiet --fixed-strings "## [$RELEASE_VERSION]" -- CHANGELOG.md; then
+    echo "Refusing to tag: CHANGELOG.md has no $RELEASE_VERSION section." >&2
+    exit 1
+fi
+
+if ! git grep --quiet --fixed-strings "const Version = \"$RELEASE_VERSION\"" -- pkg/docs/docs.go; then
+    echo "Refusing to tag: pkg/docs.Version is not $RELEASE_VERSION." >&2
+    exit 1
+fi
+
+MODULE_MISMATCHES=$(git grep -n \
+    'github.com/deepnoodle-ai/risor/v2 v' -- '**/go.mod' \
+    | grep -v " v$RELEASE_VERSION$" || true)
+if [[ -n "$MODULE_MISMATCHES" ]]; then
+    echo "Refusing to tag: nested modules do not all require v$RELEASE_VERSION:" >&2
+    echo "$MODULE_MISMATCHES" >&2
+    exit 1
+fi
+
+if git rev-parse --verify --quiet "refs/tags/$VERSION" >/dev/null; then
+    echo "Refusing to overwrite existing tag $VERSION." >&2
+    exit 1
+fi
+
+git tag "$VERSION"
+git push origin "refs/tags/$VERSION"

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 client/server
 .vscode-test
+*.tsbuildinfo


### PR DESCRIPTION
## Summary

- prepare the v2.2.0 changelog for the variadic method API, closure and wrapped-error fixes, memory-limit guidance, and dependency updates
- align embedded documentation and nested-module versions on 2.2.0
- make GoReleaser inject version, commit, and build-date metadata into release binaries
- add a non-publishing release snapshot gate and modernize the GoReleaser archive configuration
- migrate Homebrew publication from the deprecated formula generator to a generated cask
- harden the release tag helper and document the complete release, verification, Docker, Homebrew, and VS Code extension procedures

## Why

Risor has accumulated a public additive API and multiple fixes since v2.1.0, so the next semantic version is v2.2.0.

The release audit also found that the published v2.1.0 CLI reports `dev`, the embedded documentation version was still `2.0.0`, and the checked-in GoReleaser configuration used deprecated archive and Homebrew fields. The old tag helper also created a second CLI-module tag that was not part of any v2 release.

This change makes the release inputs consistent and adds preflight checks before any tag or public artifact is created.

## Impact

After this PR merges and `main` CI passes, the release can be tagged with `scripts/tag.sh v2.2.0` and published with `make release`.

The v2.2.0 release will be the first cask-based Homebrew release. Once the cask is published and verified, the stale unversioned `Formula/risor.rb` should be removed from the tap while preserving `Formula/risor@1.rb`.

The VS Code extension remains independently versioned and is not published by the Risor release target.

## Validation

- `make test` — 3,951 tests passed
- `make generate`
- `make format`
- `go test ./...` across all nested modules, including the Tetra3D example
- `go vet ./...` across the root and nested modules
- `make release-snapshot`
- all seven generated archives verified against `checksums.txt`
- generated CLI reports snapshot version metadata instead of `dev`
- generated Homebrew cask passes Ruby syntax validation
- VS Code extension compiles and packages successfully
- `npm audit --audit-level=high` reports zero vulnerabilities
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released Risor 2.2.0 with variadic method definitions and improved runtime behavior.
  * Added version, commit, and build-date metadata to packaged binaries.
  * Added Windows ZIP archives and macOS Homebrew cask distribution.

* **Bug Fixes**
  * Improved wrapped error comparisons and closure behavior across reused execution frames.

* **Documentation**
  * Added memory-limit guidance and expanded release, installation, and VS Code extension documentation.

* **Chores**
  * Added release snapshot tooling and stronger release validation.
  * Updated displayed version information to 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->